### PR TITLE
Add wall-static QA indices and gating

### DIFF
--- a/kielproc_monorepo/duct_dp_visualizer.py
+++ b/kielproc_monorepo/duct_dp_visualizer.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+import numpy as np
+from dataclasses import dataclass
+from typing import Iterable
+
+
+def pearson_r(x: Iterable[float], y: Iterable[float]) -> float:
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(y, dtype=float)
+    if x.size != y.size:
+        raise ValueError("x and y must have same length")
+    if x.size == 0:
+        return float("nan")
+    return float(np.corrcoef(x, y)[0, 1])
+
+
+def fisher_z_ci(r: float, n: int, alpha: float = 0.05):
+    """Return correlation and Fisher z-transformed confidence interval."""
+    if n <= 3 or abs(r) >= 1:
+        return r, float("nan"), float("nan")
+    z = np.arctanh(r)
+    se = 1.0 / np.sqrt(n - 3)
+    zcrit = 1.96  # approximate 95% two-sided
+    lo = np.tanh(z - zcrit * se)
+    hi = np.tanh(z + zcrit * se)
+    return r, float(lo), float(hi)
+
+
+def _theil_sen_slope(x: np.ndarray, y: np.ndarray) -> float:
+    """Median slope of all pairs (Theil-Sen estimator)."""
+    n = x.size
+    idx_i, idx_j = np.triu_indices(n, k=1)
+    slopes = (y[idx_j] - y[idx_i]) / (x[idx_j] - x[idx_i])
+    return float(np.median(slopes))
+
+
+def theil_sen_subsample_ci(x, y, B=100, pairs_per_boot=200, seed=None):
+    rng = np.random.default_rng(seed)
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(y, dtype=float)
+    m_hat = _theil_sen_slope(x, y)
+    boot = []
+    n = x.size
+    for _ in range(B):
+        i = rng.integers(0, n, size=pairs_per_boot)
+        j = rng.integers(0, n, size=pairs_per_boot)
+        mask = i < j
+        i = i[mask]; j = j[mask]
+        if i.size == 0:
+            continue
+        slopes = (y[j] - y[i]) / (x[j] - x[i])
+        boot.append(np.median(slopes))
+    if boot:
+        lo, hi = np.percentile(boot, [2.5, 97.5])
+    else:
+        lo = hi = float("nan")
+    return m_hat, float(lo), float(hi)
+
+
+@dataclass
+class SliceParams:
+    frac: float = 0.1
+    kmin: int = 10
+
+
+def analyze_port(df, params: SliceParams):
+    """Split a DataFrame into bottom/middle/top slices and compute slopes."""
+    x = np.asarray(df["SP"], dtype=float)
+    y = np.asarray(df["VP"], dtype=float)
+    n = x.size
+    k = max(int(params.frac * n), params.kmin)
+    slices = {
+        "bottom": slice(0, k),
+        "middle": slice(max((n - k) // 2, 0), max((n + k) // 2, 0)),
+        "top": slice(n - k, n),
+    }
+    rows = []
+    for name, sl in slices.items():
+        xs = x[sl]; ys = y[sl]
+        if xs.size >= params.kmin:
+            m = _theil_sen_slope(xs, ys)
+            rows.append(dict(Slice=name, theil_sen=m))
+    import pandas as pd
+    return pd.DataFrame(rows)

--- a/kielproc_monorepo/kielproc/__init__.py
+++ b/kielproc_monorepo/kielproc/__init__.py
@@ -9,6 +9,7 @@ from .pooling import pool_alpha_beta_random_effects
 from .io import load_legacy_excel, load_logger_csv, unify_schema
 from .translate import compute_translation_table, apply_translation
 from .report import write_summary_tables, plot_alignment
+from .qa import qa_indices
 
 __all__ = [
     "map_qs_to_qt", "venturi_dp_from_qt", "rho_from_pT",
@@ -17,5 +18,5 @@ __all__ = [
     "pool_alpha_beta_random_effects",
     "load_legacy_excel", "load_logger_csv", "unify_schema",
     "compute_translation_table", "apply_translation",
-    "write_summary_tables", "plot_alignment",
+    "write_summary_tables", "plot_alignment", "qa_indices",
 ]

--- a/kielproc_monorepo/kielproc/qa.py
+++ b/kielproc_monorepo/kielproc/qa.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+import math
+
+def qa_indices(pN: float, pS: float, pE: float, pW: float, q_mean: float):
+    """Compute 90° wall-static quality indices.
+
+    Parameters
+    ----------
+    pN,pS,pE,pW : float
+        Mean wall-static pressures at the north, south, east and west ports.
+    q_mean : float
+        Mean dynamic pressure used for normalisation.
+
+    Returns
+    -------
+    (delta_opp, W) : tuple of floats
+        ``delta_opp`` is the maximum opposing-port difference divided by ``q_mean``.
+        ``W`` is the swirl index based on the root-sum-square of opposing differences,
+        normalised by ``2*q_mean``.
+    """
+    pN = float(pN); pS = float(pS); pE = float(pE); pW = float(pW); q_mean = float(q_mean)
+    if q_mean == 0 or math.isnan(q_mean):
+        return float("nan"), float("nan")
+    d_ns = pN - pS
+    d_ew = pE - pW
+    delta_opp = max(abs(d_ns), abs(d_ew)) / q_mean
+    W = math.sqrt(d_ns*d_ns + d_ew*d_ew) / (2.0 * q_mean)
+    return delta_opp, W

--- a/kielproc_monorepo/kielproc/report.py
+++ b/kielproc_monorepo/kielproc/report.py
@@ -8,9 +8,10 @@ from pathlib import Path
 def write_summary_tables(outdir: Path, per_block: pd.DataFrame, pooled: dict | None):
     outdir.mkdir(parents=True, exist_ok=True)
     per_block.to_csv(outdir / "alpha_beta_by_block.csv", index=False)
-    files = [str(outdir / "alpha_beta_by_block.csv")]
+    import json
+    (outdir / "alpha_beta_by_block.json").write_text(json.dumps(per_block.to_dict(orient="records"), indent=2))
+    files = [str(outdir / "alpha_beta_by_block.csv"), str(outdir / "alpha_beta_by_block.json")]
     if pooled:
-        import json
         pd.DataFrame([pooled]).to_csv(outdir / "alpha_beta_pooled.csv", index=False)
         files.append(str(outdir / "alpha_beta_pooled.csv"))
         (outdir / "alpha_beta_pooled.json").write_text(json.dumps(pooled, indent=2))

--- a/kielproc_monorepo/tests/test_qa.py
+++ b/kielproc_monorepo/tests/test_qa.py
@@ -1,0 +1,50 @@
+import pandas as pd
+import numpy as np
+from pathlib import Path
+from kielproc.qa import qa_indices
+from kielproc.cli import main as cli_main
+
+
+def test_qa_indices_basic():
+    d, w = qa_indices(100, 102, 101, 99, 50)
+    assert np.isclose(d, 0.04)
+    assert np.isclose(w, np.sqrt(8)/(100))
+
+
+def test_fit_records_qa(tmp_path: Path):
+    # create simple CSV
+    df = pd.DataFrame({
+        "mapped_ref": [1,2,3,4],
+        "piccolo": [1.1,2.1,3.1,4.1],
+        "pN": [100,100,100,100],
+        "pS": [102,102,102,102],
+        "pE": [101,101,101,101],
+        "pW": [99,99,99,99],
+        "q_mean": [50,50,50,50],
+    })
+    csv = tmp_path/"block.csv"; df.to_csv(csv, index=False)
+    outdir = tmp_path/"out"
+    cli_main(["fit","--blocks",f"b1={csv}","--outdir",str(outdir),"--qa-gate-opp","0.05","--qa-gate-w","0.05"])
+    tbl = pd.read_csv(outdir/"alpha_beta_by_block.csv")
+    assert "delta_opp" in tbl.columns and "W" in tbl.columns and "qa_pass" in tbl.columns
+    assert bool(tbl.loc[0,"qa_pass"]) is True
+
+
+def test_fit_gate_fail(tmp_path: Path):
+    df = pd.DataFrame({
+        "mapped_ref": [1,2,3,4],
+        "piccolo": [1.1,2.1,3.1,4.1],
+        "pN": [100,100,100,100],
+        "pS": [105,105,105,105],
+        "pE": [101,101,101,101],
+        "pW": [99,99,99,99],
+        "q_mean": [50,50,50,50],
+    })
+    csv = tmp_path/"block.csv"; df.to_csv(csv, index=False)
+    outdir = tmp_path/"out"
+    try:
+        cli_main(["fit","--blocks",f"b1={csv}","--outdir",str(outdir),"--qa-gate-opp","0.01","--qa-gate-w","0.01"])
+    except SystemExit:
+        pass
+    tbl = pd.read_csv(outdir/"alpha_beta_by_block.csv")
+    assert bool(tbl.loc[0,"qa_pass"]) is False


### PR DESCRIPTION
## Summary
- add `qa_indices` for 90° wall-static ring health metrics
- gate translation fit by configurable Δ_opp/W thresholds and record metrics in reports
- export per-block results to JSON and test QA workflow

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68b3bbef8d5c8322b850b469575c749e