### PR TITLE
feat: add bivariate random-effects pooling

### DIFF
--- a/kielproc_monorepo/kielproc/pooling.py
+++ b/kielproc_monorepo/kielproc/pooling.py
@@ -1,26 +1,73 @@
 
 import numpy as np
 
-def pool_alpha_beta_random_effects(alphas, alpha_vars, betas, beta_vars):
+
+def pool_alpha_beta_random_effects(alphas, alpha_vars, betas, beta_vars, cov_ab=None):
+    """Random-effects pooling for correlated alpha/beta estimates.
+
+    Parameters
+    ----------
+    alphas, betas : array-like
+        Per-replicate estimates of slope (alpha) and intercept (beta).
+    alpha_vars, beta_vars : array-like
+        Corresponding variances for alpha and beta.
+    cov_ab : array-like or None, optional
+        Per-replicate covariances between alpha and beta.  If omitted,
+        covariances are assumed to be zero.
+
+    Returns
+    -------
+    tuple
+        ``(alpha_pooled, alpha_se, tau2_alpha, beta_pooled, beta_se, tau2_beta,
+        (Q_alpha, k_alpha), (Q_beta, k_beta), cov_pooled)`` where ``cov_pooled``
+        is the 2x2 covariance matrix of the pooled estimates.
     """
-    Random-effects (DerSimonian–Laird) pooling for alpha and beta separately.
-    Returns: (alpha_pooled, alpha_se, tau2_alpha, beta_pooled, beta_se, tau2_beta, (Q_alpha,k_alpha), (Q_beta,k_beta))
-    """
+
     alphas = np.asarray(alphas, dtype=float)
-    betas  = np.asarray(betas, dtype=float)
+    betas = np.asarray(betas, dtype=float)
     Va = np.asarray(alpha_vars, dtype=float)
     Vb = np.asarray(beta_vars, dtype=float)
-    def _pool(theta, V):
+    if cov_ab is None:
+        cov_ab = np.zeros_like(Va, dtype=float)
+    else:
+        cov_ab = np.asarray(cov_ab, dtype=float)
+
+    def _pool_univariate(theta, V):
         w_FE = 1.0 / V
-        theta_FE = np.sum(w_FE*theta)/np.sum(w_FE)
-        Q = np.sum(w_FE*(theta - theta_FE)**2)
+        theta_FE = np.sum(w_FE * theta) / np.sum(w_FE)
+        Q = np.sum(w_FE * (theta - theta_FE) ** 2)
         k = theta.size
-        c = np.sum(w_FE) - np.sum(w_FE**2)/np.sum(w_FE)
+        c = np.sum(w_FE) - np.sum(w_FE ** 2) / np.sum(w_FE)
         tau2 = max(0.0, (Q - (k - 1)) / max(c, 1e-12))
-        w_RE = 1.0 / (V + tau2)
-        theta_RE = np.sum(w_RE*theta)/np.sum(w_RE)
-        se_RE = np.sqrt(1.0/np.sum(w_RE))
-        return theta_RE, se_RE, tau2, Q, k
-    a_hat, a_se, tau2_a, Q_a, k_a = _pool(alphas, Va)
-    b_hat, b_se, tau2_b, Q_b, k_b = _pool(betas,  Vb)
-    return a_hat, a_se, tau2_a, b_hat, b_se, tau2_b, (Q_a, k_a), (Q_b, k_b)
+        return tau2, Q, k
+
+    tau2_a, Q_a, k_a = _pool_univariate(alphas, Va)
+    tau2_b, Q_b, k_b = _pool_univariate(betas, Vb)
+
+    # Construct covariance matrices including between-study variance
+    T = np.array([[tau2_a, 0.0], [0.0, tau2_b]])
+    Sum_W = np.zeros((2, 2))
+    Sum_Wtheta = np.zeros(2)
+
+    for a, b, v_a, v_b, cab in zip(alphas, betas, Va, Vb, cov_ab):
+        Sigma = np.array([[v_a, cab], [cab, v_b]]) + T
+        W = np.linalg.inv(Sigma)
+        Sum_W += W
+        Sum_Wtheta += W @ np.array([a, b])
+
+    cov_pooled = np.linalg.inv(Sum_W)
+    pooled = cov_pooled @ Sum_Wtheta
+    a_hat, b_hat = pooled
+    a_se, b_se = np.sqrt(np.diag(cov_pooled))
+
+    return (
+        float(a_hat),
+        float(a_se),
+        float(tau2_a),
+        float(b_hat),
+        float(b_se),
+        float(tau2_b),
+        (float(Q_a), int(k_a)),
+        (float(Q_b), int(k_b)),
+        cov_pooled,
+    )

--- a/kielproc_monorepo/kielproc/translate.py
+++ b/kielproc_monorepo/kielproc/translate.py
@@ -25,9 +25,12 @@ def compute_translation_table(blocks: dict, ref_key="mapped_ref", picc_key="picc
     if not tidy.empty and tidy["alpha_se"].gt(0).all() and tidy["beta_se"].gt(0).all():
         Va = tidy["alpha_se"]**2
         Vb = tidy["beta_se"]**2
-        a_hat, a_se, tau2_a, b_hat, b_se, tau2_b, Q_a, Q_b = pool_alpha_beta_random_effects(tidy["alpha"], Va, tidy["beta"], Vb)
+        cov_ab = np.zeros_like(Va)
+        a_hat, a_se, tau2_a, b_hat, b_se, tau2_b, Q_a, Q_b, cov_pooled = \
+            pool_alpha_beta_random_effects(tidy["alpha"], Va, tidy["beta"], Vb, cov_ab)
         pooled = dict(alpha=a_hat, alpha_se=a_se, tau2_alpha=tau2_a,
                       beta=b_hat,  beta_se=b_se,  tau2_beta=tau2_b,
+                      cov_ab=cov_pooled[0, 1],
                       Q_alpha=Q_a[0], k_alpha=Q_a[1], Q_beta=Q_b[0], k_beta=Q_b[1])
     return tidy.reset_index(), pooled
 

--- a/kielproc_monorepo/tests/test_kielproc_basic.py
+++ b/kielproc_monorepo/tests/test_kielproc_basic.py
@@ -34,6 +34,10 @@ def test_pooling_workflow():
     alpha_vars = np.array([0.01, 0.01, 0.02])
     betas = np.array([2.0, 1.0, 1.5])
     beta_vars = np.array([0.5, 0.5, 0.6])
-    a_hat, a_se, tau2_a, b_hat, b_se, tau2_b, *_ = pool_alpha_beta_random_effects(alphas, alpha_vars, betas, beta_vars)
+    cov_ab = np.array([0.02, 0.01, 0.015])
+    a_hat, a_se, tau2_a, b_hat, b_se, tau2_b, Q_a, Q_b, cov = \
+        pool_alpha_beta_random_effects(alphas, alpha_vars, betas, beta_vars, cov_ab)
     assert 0.8 < a_hat < 1.2
     assert a_se > 0
+    assert cov.shape == (2, 2)
+    assert cov[0, 1] > 0


### PR DESCRIPTION
## Summary
- support generalized least-squares pooling of correlated alpha/beta estimates
- track per-parameter heterogeneity (tau^2) and Q statistics while returning pooled covariance
- assume zero cross-covariance in translation tables but expose pooled alpha-beta covariance

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b3c1a1f9a48322b5f7d56332ca1532