### PR TITLE
Expose absolute cross-correlation lag option

### DIFF
--- a/kielproc_monorepo/tests/test_lag.py
+++ b/kielproc_monorepo/tests/test_lag.py
@@ -1,0 +1,18 @@
+import numpy as np
+from kielproc.lag import estimate_lag_xcorr
+
+
+def test_estimate_lag_xcorr_defaults_to_abs():
+    x = np.array([0, 1, 1, 0], dtype=float)
+    y = -x
+    lag, lags, c = estimate_lag_xcorr(x, y)
+    assert lag == 0
+    # ensure returned cross-correlation is signed
+    assert c[lags.tolist().index(0)] < 0
+
+
+def test_estimate_lag_xcorr_signed_option():
+    x = np.array([0, 1, 1, 0], dtype=float)
+    y = -x
+    lag, _, _ = estimate_lag_xcorr(x, y, use_abs=False)
+    assert lag in (-2, 2)


### PR DESCRIPTION
## Summary
- add `use_abs` toggle to `estimate_lag_xcorr` for maximizing |r(τ)| by default
- cover negative correlation handling with dedicated tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b3c7ef8dd48322bb099e2189bdb7b9