### PR TITLE
Implement GLS pooling for alpha/beta estimates

### DIFF
--- a/kielproc_monorepo/kielproc/__init__.py
+++ b/kielproc_monorepo/kielproc/__init__.py
@@ -5,7 +5,7 @@ kielproc - Kiel + wall-static baseline processor & legacy piccolo translation.
 from .physics import map_qs_to_qt, venturi_dp_from_qt, rho_from_pT
 from .lag import estimate_lag_xcorr, shift_series, advance_series, delay_series
 from .deming import deming_fit
-from .pooling import pool_alpha_beta_random_effects
+from .pooling import pool_alpha_beta_random_effects, pool_alpha_beta_gls
 from .io import load_legacy_excel, load_logger_csv, unify_schema
 from .translate import compute_translation_table, apply_translation
 from .report import write_summary_tables, plot_alignment
@@ -15,7 +15,7 @@ __all__ = [
     "map_qs_to_qt", "venturi_dp_from_qt", "rho_from_pT",
     "estimate_lag_xcorr", "shift_series", "advance_series", "delay_series",
     "deming_fit",
-    "pool_alpha_beta_random_effects",
+    "pool_alpha_beta_random_effects", "pool_alpha_beta_gls",
     "load_legacy_excel", "load_logger_csv", "unify_schema",
     "compute_translation_table", "apply_translation",
     "write_summary_tables", "plot_alignment", "qa_indices",


### PR DESCRIPTION
## Summary
- add `pool_alpha_beta_gls` for generalized least squares pooling of correlated alpha/beta replicates
- expose GLS pooling from package namespace
- test GLS pooling against manual calculation

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b3cf5443108322a003f41ec41dd288