### PR TITLE
feat: expose QA thresholds in GUI

### DIFF
--- a/kielproc_monorepo/gui/app_gui.py
+++ b/kielproc_monorepo/gui/app_gui.py
@@ -24,6 +24,7 @@ from kielproc_gui_adapter import (
     fit_alpha_beta, translate_piccolo,
     generate_flow_map_from_csv, generate_polar_slice_from_csv
 )
+from kielproc.qa import DEFAULT_W_MAX, DEFAULT_DELTA_OPP_MAX
 
 class App(tk.Tk):
     def __init__(self):
@@ -96,8 +97,8 @@ class App(tk.Tk):
         self.var_pE = tk.StringVar(value="pE")
         self.var_pW = tk.StringVar(value="pW")
         self.var_qmean = tk.StringVar(value="q_mean")
-        self.var_gate_opp = tk.StringVar(value="")
-        self.var_gate_w = tk.StringVar(value="")
+        self.var_gate_opp = tk.StringVar(value=str(DEFAULT_DELTA_OPP_MAX))
+        self.var_gate_w = tk.StringVar(value=str(DEFAULT_W_MAX))
         ttk.Label(frm, text="Replicate blocks (name=path.csv, comma-separated)").grid(row=row, column=0, sticky="e", **pad)
         ttk.Entry(frm, textvariable=self.var_blocks, width=64).grid(row=row, column=1, columnspan=3, sticky="w", **pad); row+=1
         ttk.Label(frm, text="ref col").grid(row=row, column=0, sticky="e", **pad)
@@ -117,11 +118,15 @@ class App(tk.Tk):
         ttk.Label(frm, text="pW col").grid(row=row, column=2, sticky="e", **pad)
         ttk.Entry(frm, textvariable=self.var_pW, width=10).grid(row=row, column=3, sticky="w", **pad); row+=1
         ttk.Label(frm, text="q_mean col").grid(row=row, column=0, sticky="e", **pad)
-        ttk.Entry(frm, textvariable=self.var_qmean, width=10).grid(row=row, column=1, sticky="w", **pad)
-        ttk.Label(frm, text="Δ_opp max").grid(row=row, column=2, sticky="e", **pad)
-        ttk.Entry(frm, textvariable=self.var_gate_opp, width=10).grid(row=row, column=3, sticky="w", **pad); row+=1
-        ttk.Label(frm, text="W max").grid(row=row, column=0, sticky="e", **pad)
-        ttk.Entry(frm, textvariable=self.var_gate_w, width=10).grid(row=row, column=1, sticky="w", **pad); row+=1
+        ttk.Entry(frm, textvariable=self.var_qmean, width=10).grid(row=row, column=1, sticky="w", **pad); row+=1
+
+        qa_frm = ttk.LabelFrame(frm, text="QA thresholds")
+        qa_frm.grid(row=row, column=0, columnspan=4, sticky="ew", **pad); row+=1
+        ttk.Label(qa_frm, text="Δ_opp max").grid(row=0, column=0, sticky="e", **pad)
+        ttk.Entry(qa_frm, textvariable=self.var_gate_opp, width=10).grid(row=0, column=1, sticky="w", **pad)
+        ttk.Label(qa_frm, text="W max").grid(row=1, column=0, sticky="e", **pad)
+        ttk.Entry(qa_frm, textvariable=self.var_gate_w, width=10).grid(row=1, column=1, sticky="w", **pad)
+
         ttk.Button(frm, text="Fit α,β (with lag removal)", command=self._do_fit).grid(row=row, column=1, sticky="w", **pad); row+=1
 
         # Apply translation

--- a/kielproc_monorepo/kielproc/qa.py
+++ b/kielproc_monorepo/kielproc/qa.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 import math
 
+# Default QA thresholds used when gating data.  Values are fractions of
+# dynamic pressure and correspond to 0.2% swirl and 1% opposing-port
+# imbalance respectively.
+DEFAULT_W_MAX = 0.002
+DEFAULT_DELTA_OPP_MAX = 0.01
+
+
 def qa_indices(pN: float, pS: float, pE: float, pW: float, q_mean: float):
     """Compute 90° wall-static quality indices.
 

--- a/kielproc_monorepo/kielproc_gui_adapter.py
+++ b/kielproc_monorepo/kielproc_gui_adapter.py
@@ -11,6 +11,7 @@ from kielproc.physics import map_qs_to_qt, venturi_dp_from_qt
 from kielproc.translate import compute_translation_table, apply_translation
 from kielproc.lag import shift_series, first_order_lag
 from kielproc.report import write_summary_tables, plot_alignment
+from kielproc.qa import qa_indices, DEFAULT_DELTA_OPP_MAX, DEFAULT_W_MAX
 
 def map_verification_plane(csv_path: Path, qs_col: str, r: float, beta: float, sampling_hz: float|None, out_path: Path) -> Path:
     df = pd.read_csv(csv_path)
@@ -38,8 +39,8 @@ def fit_alpha_beta(
     pE_col: str = "pE",
     pW_col: str = "pW",
     q_mean_col: str = "q_mean",
-    qa_gate_opp: float | None = None,
-    qa_gate_w: float | None = None,
+    qa_gate_opp: float | None = DEFAULT_DELTA_OPP_MAX,
+    qa_gate_w: float | None = DEFAULT_W_MAX,
 ) -> Dict[str, object]:
     blocks = {name: pd.read_csv(path) for name, path in block_specs.items()}
     per_block, pooled = compute_translation_table(
@@ -51,7 +52,6 @@ def fit_alpha_beta(
     )
 
     # QA indices similar to CLI
-    from kielproc.qa import qa_indices
     qa_rows = []
     for name, df in blocks.items():
         pN = df[pN_col].mean()

--- a/kielproc_monorepo/tests/test_qa.py
+++ b/kielproc_monorepo/tests/test_qa.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import numpy as np
 from pathlib import Path
-from kielproc.qa import qa_indices
+from kielproc.qa import qa_indices, DEFAULT_DELTA_OPP_MAX, DEFAULT_W_MAX
 from kielproc.cli import main as cli_main
 
 
@@ -9,6 +9,11 @@ def test_qa_indices_basic():
     d, w = qa_indices(100, 102, 101, 99, 50)
     assert np.isclose(d, 0.04)
     assert np.isclose(w, np.sqrt(8)/(100))
+
+
+def test_qa_default_thresholds():
+    assert np.isclose(DEFAULT_DELTA_OPP_MAX, 0.01)
+    assert np.isclose(DEFAULT_W_MAX, 0.002)
 
 
 def test_fit_records_qa(tmp_path: Path):


### PR DESCRIPTION
## Summary
- add default QA thresholds (W and Δ_opp/mean(q)) to qa module
- expose QA thresholds in GUI panel with adjustable values
- pass default QA gates via GUI adapter and add tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68b3d1310550832280920b3ed6e9f625