### PR TITLE
Integrate Geometry-based venturi mapping and GUI controls

### DIFF
--- a/kielproc_monorepo/kielproc/__init__.py
+++ b/kielproc_monorepo/kielproc/__init__.py
@@ -17,6 +17,7 @@ from .geometry import (
     throat_area,
     r_ratio,
     beta_from_geometry,
+    geometry_summary,
 )
 
 __all__ = [
@@ -27,5 +28,5 @@ __all__ = [
     "load_legacy_excel", "load_logger_csv", "unify_schema",
     "compute_translation_table", "apply_translation",
     "write_summary_tables", "plot_alignment", "qa_indices",
-    "Geometry", "plane_area", "effective_upstream_area", "throat_area", "r_ratio", "beta_from_geometry",
+    "Geometry", "plane_area", "effective_upstream_area", "throat_area", "r_ratio", "beta_from_geometry", "geometry_summary",
 ]

--- a/kielproc_monorepo/kielproc/geometry.py
+++ b/kielproc_monorepo/kielproc/geometry.py
@@ -41,6 +41,29 @@ def beta_from_geometry(g: Geometry) -> float:
     At = throat_area(g)
     return math.sqrt(At / A1)
 
+
+def geometry_summary(g: Geometry) -> dict:
+    """Return a dictionary of key geometric parameters.
+
+    Values are computed at full precision; callers may format for
+    display without altering the stored float values.
+    """
+    As = plane_area(g)
+    At = throat_area(g)
+    A1 = effective_upstream_area(g)
+    return {
+        "duct_height_m": g.duct_height_m,
+        "duct_width_m": g.duct_width_m,
+        "As_m2": As,
+        "upstream_area_m2": g.upstream_area_m2,
+        "A1_m2": A1,
+        "At_m2": At,
+        "r": r_ratio(g),
+        "beta": beta_from_geometry(g),
+        "rho_default_kg_m3": g.rho_default_kg_m3,
+        "A1_auto_from_As": g.upstream_area_m2 is None,
+    }
+
 @dataclass
 class DiffuserGeometry:
     D1: float  # inlet diameter [m]


### PR DESCRIPTION
## Summary
- Introduce `geometry_summary` helper and export for downstream use
- Update mapping adapters to derive r and beta from `Geometry` and persist geometry fields
- Replace manual r/beta GUI inputs with duct and throat geometry controls and auto-computed values
- Add regression test ensuring mapping functions respect geometry data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68b3d6315b4c8322a147b3ed651b957c