### PR TITLE
Stabilize Deming regression variance with bootstrap option

### DIFF
--- a/kielproc_monorepo/kielproc/deming.py
+++ b/kielproc_monorepo/kielproc/deming.py
@@ -1,33 +1,79 @@
 
 import numpy as np
 
-def deming_fit(x, y, lambda_ratio: float = 1.0):
+
+def deming_fit(
+    x,
+    y,
+    lambda_ratio: float = 1.0,
+    *,
+    bootstrap: bool = False,
+    n_boot: int = 200,
+    random_state: int | None = None,
+):
+    """Deming regression with optional bootstrap standard errors.
+
+    Parameters
+    ----------
+    x, y : array_like
+        Input data.  Must be finite.
+    lambda_ratio : float, optional
+        Known variance ratio :math:`\lambda = \sigma_y^2 / \sigma_x^2`.
+    bootstrap : bool, optional
+        If True, compute standard errors via bootstrap rather than the
+        large-sample approximation.  Defaults to False.
+    n_boot : int, optional
+        Number of bootstrap resamples when ``bootstrap`` is True.
+    random_state : int, optional
+        Seed for bootstrap RNG.
     """
-    Deming regression (errors-in-variables) with known variance ratio lambda = sigma_y^2 / sigma_x^2.
-    Returns alpha (slope), beta (intercept), and standard errors (sa, sb) using asymptotic formulas.
-    """
+
     x = np.asarray(x, dtype=float)
     y = np.asarray(y, dtype=float)
     mask = np.isfinite(x) & np.isfinite(y)
-    x = x[mask]; y = y[mask]
+    x = x[mask]
+    y = y[mask]
     n = x.size
     if n < 3:
         return np.nan, np.nan, np.nan, np.nan
-    xbar = np.mean(x); ybar = np.mean(y)
-    Sxx = np.mean((x - xbar)**2)
-    Syy = np.mean((y - ybar)**2)
-    Sxy = np.mean((x - xbar)*(y - ybar))
+    xbar = np.mean(x)
+    ybar = np.mean(y)
+    Sxx = np.mean((x - xbar) ** 2)
+    Syy = np.mean((y - ybar) ** 2)
+    Sxy = np.mean((x - xbar) * (y - ybar))
     if Sxy == 0:
         return np.nan, np.nan, np.nan, np.nan
 
-    term = (Syy - lambda_ratio*Sxx)
-    D = term**2 + 4*lambda_ratio*(Sxy**2)
-    alpha = (term + np.sqrt(D)) / (2*Sxy)
+    term = Syy - lambda_ratio * Sxx
+    D = term**2 + 4 * lambda_ratio * (Sxy**2)
+    alpha = (term + np.sqrt(D)) / (2 * Sxy)
     beta = ybar - alpha * xbar
 
-    # Large-sample variance approximations
-    var_alpha = ((alpha**2 + lambda_ratio) / (n * (Sxy**2))) * (lambda_ratio*Sxx + Syy - 2*alpha*Sxy)
-    var_beta  = var_alpha*(xbar**2) + (alpha**2 * (Sxx/n)) + ((lambda_ratio*Sxx + Syy - 2*alpha*Sxy) / n)
-    sa = float(np.sqrt(max(var_alpha, 0.0)))
-    sb = float(np.sqrt(max(var_beta, 0.0)))
+    if bootstrap:
+        rng = np.random.default_rng(random_state)
+        idx = np.arange(n)
+        coefs = []
+        for _ in range(n_boot):
+            samp = rng.choice(idx, size=n, replace=True)
+            a_s, b_s, _, _ = deming_fit(
+                x[samp],
+                y[samp],
+                lambda_ratio=lambda_ratio,
+                bootstrap=False,
+            )
+            coefs.append((a_s, b_s))
+        coefs = np.asarray(coefs)
+        sa = float(np.std(coefs[:, 0], ddof=1))
+        sb = float(np.std(coefs[:, 1], ddof=1))
+        return float(alpha), float(beta), sa, sb
+
+    # Large-sample variance approximations with small ridge for stability
+    resid = lambda_ratio * Sxx + Syy - 2 * alpha * Sxy
+    resid = max(resid, 0.0)
+    eps = np.finfo(float).eps
+    denom = Sxy**2
+    var_alpha = ((alpha**2 + lambda_ratio) / (n * (denom + eps))) * (resid + eps)
+    var_beta = var_alpha * (xbar**2) + (alpha**2 * (Sxx / n)) + ((resid + eps) / n)
+    sa = float(np.sqrt(var_alpha))
+    sb = float(np.sqrt(var_beta))
     return float(alpha), float(beta), sa, sb

--- a/kielproc_monorepo/tests/test_kielproc_basic.py
+++ b/kielproc_monorepo/tests/test_kielproc_basic.py
@@ -27,7 +27,19 @@ def test_deming_known_slope():
     y_noisy = y_true + rng.normal(scale=0.2, size=x.size)
     a, b, sa, sb = deming_fit(x_noisy, y_noisy, lambda_ratio=1.0)
     assert 1.6 < a < 2.4
-    assert sa >= 0.0
+    assert sa > 0.0
+    assert sb > 0.0
+
+
+def test_deming_se_not_zero_with_noise():
+    rng = np.random.default_rng(1)
+    x = np.linspace(0, 5, 100)
+    y_true = -1.0 + 0.5 * x
+    x_noisy = x + rng.normal(scale=0.05, size=x.size)
+    y_noisy = y_true + rng.normal(scale=0.05, size=x.size)
+    _, _, sa, sb = deming_fit(x_noisy, y_noisy, lambda_ratio=1.0)
+    assert sa > 0.0
+    assert sb > 0.0
 
 def test_pooling_workflow():
     alphas = np.array([0.9, 1.1, 1.0])


### PR DESCRIPTION
## Summary
- stabilize Deming regression variance calculation with small ridge
- add optional bootstrap-based standard errors
- add tests ensuring SE is non-zero when data has variance

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b3e2fc7e28832299db683691d69af7