### PR TITLE
Add MIT license to project metadata

### DIFF
--- a/kielproc_monorepo/pyproject.toml
+++ b/kielproc_monorepo/pyproject.toml
@@ -8,6 +8,7 @@ name = "kielproc-suite"
 version = "0.1.0"
 description = "Kiel + wall-static baseline and legacy piccolo translation, with Tk GUI"
 authors = [{name="Brandon's helper"}]
+license = "MIT"
 dependencies = [
     "numpy>=1.24",
     "pandas>=2.0",


### PR DESCRIPTION
## Summary
- declare MIT license in pyproject.toml project metadata

## Testing
- `pip install -r kielproc_monorepo/requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b3f0f381bc83228c1caf6c8ec78f5e