### PR TITLE
Add results CLI and packaging metadata

### DIFF
--- a/kielproc_monorepo/kielproc/__init__.py
+++ b/kielproc_monorepo/kielproc/__init__.py
@@ -2,6 +2,17 @@
 """
 kielproc - Kiel + wall-static baseline processor & legacy piccolo translation.
 """
+
+try:  # pragma: no cover - version lookup is trivial
+    from importlib.metadata import PackageNotFoundError, version
+except ImportError:  # pragma: no cover
+    from importlib_metadata import PackageNotFoundError, version
+
+try:  # pragma: no cover
+    __version__ = version("kielproc-suite")
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "0.0.0"
+
 from .physics import map_qs_to_qt, venturi_dp_from_qt, rho_from_pT
 from .lag import estimate_lag_xcorr, shift_series, advance_series, delay_series
 from .deming import deming_fit
@@ -22,6 +33,7 @@ from .geometry import (
 from .legacy_results import ResultsConfig, compute_results as compute_legacy_results
 
 __all__ = [
+    "__version__",
     "map_qs_to_qt", "venturi_dp_from_qt", "rho_from_pT",
     "estimate_lag_xcorr", "shift_series", "advance_series", "delay_series",
     "deming_fit",

--- a/kielproc_monorepo/pyproject.toml
+++ b/kielproc_monorepo/pyproject.toml
@@ -16,6 +16,9 @@ dependencies = [
     "openpyxl>=3.1",
 ]
 
+[project.scripts]
+kielproc = "kielproc.cli:main"
+
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["kielproc*"]

--- a/kielproc_monorepo/tests/test_cli_results.py
+++ b/kielproc_monorepo/tests/test_cli_results.py
@@ -1,0 +1,44 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+import pandas as pd
+
+
+def test_cli_results(tmp_path: Path):
+    df = pd.DataFrame({
+        "Temperature": [20.0, 21.0, 19.5],
+        "VP": [10.0, 11.0, 9.0],
+        "Static": [101325.0, 101300.0, 101350.0],
+        "Piccolo": [12.0, 12.0, 12.0],
+    })
+    csv = tmp_path / "sample.csv"
+    df.to_csv(csv, index=False)
+    cfg = {
+        "static_col": "Static",
+        "duct_height_m": 2.0,
+        "duct_width_m": 3.0,
+    }
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text(json.dumps(cfg))
+    json_out = tmp_path / "out.json"
+    csv_out = tmp_path / "out.csv"
+    cmd = [
+        sys.executable,
+        "-m",
+        "kielproc.cli",
+        "results",
+        "--csv",
+        str(csv),
+        "--config",
+        str(cfg_path),
+        "--json-out",
+        str(json_out),
+        "--csv-out",
+        str(csv_out),
+    ]
+    cp = subprocess.run(cmd, capture_output=True, check=True, text=True)
+    data = json.loads(cp.stdout)
+    assert json_out.exists()
+    assert csv_out.exists()
+    assert data["n_samples"] == 3


### PR DESCRIPTION
## Summary
- surface package version and expose console script
- add `results` subcommand wrapping `compute_results`
- test CLI `results`

## Testing
- `nox -s tests`
- `pip install -e kielproc_monorepo`
- `kielproc --help | head -n 20`


------
https://chatgpt.com/codex/tasks/task_b_68b3f1a362588322a9c2ddb04ff31eee