### PR TITLE
Fix invalid escape sequences in deming docstring

### DIFF
--- a/kielproc_monorepo/kielproc/deming.py
+++ b/kielproc_monorepo/kielproc/deming.py
@@ -11,7 +11,7 @@ def deming_fit(
     n_boot: int = 200,
     random_state: int | None = None,
 ):
-    """Deming regression with optional bootstrap standard errors.
+    r"""Deming regression with optional bootstrap standard errors.
 
     Parameters
     ----------


### PR DESCRIPTION
## Summary
- avoid SyntaxWarning from LaTeX escapes by marking `deming_fit` docstring as a raw string

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b4063bd26883228708707565db5849