### PR TITLE
Improve translation column validation

### DIFF
--- a/kielproc_monorepo/kielproc/translate.py
+++ b/kielproc_monorepo/kielproc/translate.py
@@ -54,7 +54,37 @@ def compute_translation_table(
                       Q_alpha=Q_a[0], k_alpha=Q_a[1], Q_beta=Q_b[0], k_beta=Q_b[1])
     return tidy.reset_index(), pooled
 
-def apply_translation(df: pd.DataFrame, alpha: float, beta: float, src_col="piccolo", out_col="piccolo_translated"):
+def apply_translation(
+    df: pd.DataFrame,
+    alpha: float,
+    beta: float,
+    src_col: str = "piccolo",
+    out_col: str = "piccolo_translated",
+):
+    """Apply a linear translation to a DataFrame column.
+
+    Parameters
+    ----------
+    df:
+        Input table.
+    alpha, beta:
+        Translation parameters.  ``alpha`` scales the source column and
+        ``beta`` is added to the result.
+    src_col:
+        Name of the column containing the raw piccolo values.
+    out_col:
+        Desired name of the translated column in the output DataFrame.
+
+    Raises
+    ------
+    KeyError
+        If ``src_col`` is not present in ``df``.
+    """
+
+    if src_col not in df.columns:
+        cols = ", ".join(df.columns)
+        raise KeyError(f"Column '{src_col}' not found in input dataframe. Available columns: {cols}")
+
     out = df.copy()
     out[out_col] = alpha * out[src_col] + beta
     return out

--- a/kielproc_monorepo/tests/test_translate.py
+++ b/kielproc_monorepo/tests/test_translate.py
@@ -1,0 +1,8 @@
+import pandas as pd
+import pytest
+from kielproc.translate import apply_translation
+
+def test_apply_translation_missing_column():
+    df = pd.DataFrame({'a':[1,2,3]})
+    with pytest.raises(KeyError, match="Column 'piccolo' not found"):
+        apply_translation(df, alpha=1.0, beta=0.0, src_col='piccolo')


### PR DESCRIPTION
## Summary
- validate that the specified piccolo column exists before applying translation
- add regression test for missing piccolo column

## Testing
- `python -m nox -s tests`
- `python -m nox -s smoke`


------
https://chatgpt.com/codex/tasks/task_b_68b406a021848322b637216e4b8c8ce9