### PR TITLE
feat: add in-memory legacy parser modes

### DIFF
--- a/kielproc_monorepo/kielproc_gui_adapter.py
+++ b/kielproc_monorepo/kielproc_gui_adapter.py
@@ -23,6 +23,18 @@ from kielproc.geometry import (
 from kielproc.legacy_results import ResultsConfig, compute_results as compute_legacy_results
 
 
+def parse_legacy_workbook_array(
+    xlsx_path: Path, piccolo_flat_threshold: float = 1e-6
+):
+    """Parse a legacy workbook into an in-memory cube."""
+    from tools.legacy_parser.legacy_parser.parser import parse_legacy_workbook
+
+    cube, summary = parse_legacy_workbook(
+        xlsx_path, piccolo_flat_threshold=piccolo_flat_threshold, return_mode="array"
+    )
+    return cube, summary
+
+
 def map_verification_plane(csv_or_df: Union[Path, pd.DataFrame], qs_col: str,
                            geom: Geometry, sampling_hz: float | None,
                            out_path: Path) -> Path:


### PR DESCRIPTION
## Summary
- support in-memory legacy workbook parsing with `LegacyCube`
- allow parser to return frames or array in addition to CSV files
- expose cube-returning parser API in GUI adapter

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b40c1a026083228757dc64217da0f7