### PR TITLE
Allow GUI adapter functions to consume DataFrames

### DIFF
--- a/kielproc_monorepo/kielproc/legacy_results.py
+++ b/kielproc_monorepo/kielproc/legacy_results.py
@@ -39,9 +39,9 @@ def _piccolo_to_mbar(mean_val: float, units: str, rng_mbar: float) -> float:
         return float(mean_val) / 100.0
     raise ValueError(f"Unsupported piccolo_units: {units}")
 
-def compute_results(csv_path: Path | str, cfg: ResultsConfig) -> dict:
-    """Compute legacy-style results fields from a raw logger CSV."""
-    df = pd.read_csv(csv_path)
+def compute_results(csv_or_df: Path | str | pd.DataFrame, cfg: ResultsConfig) -> dict:
+    """Compute legacy-style results fields from a raw logger CSV or DataFrame."""
+    df = pd.read_csv(csv_or_df) if isinstance(csv_or_df, (str, Path)) else pd.DataFrame(csv_or_df)
     A = _resolve_area(cfg)
 
     # Temperature (°C) and Kelvin for density calc

--- a/kielproc_monorepo/tests/test_gui_adapter_df.py
+++ b/kielproc_monorepo/tests/test_gui_adapter_df.py
@@ -1,0 +1,42 @@
+import pandas as pd
+from pathlib import Path
+from kielproc.geometry import Geometry
+from kielproc_gui_adapter import (
+    map_from_tot_and_static,
+    translate_piccolo,
+    legacy_results_from_csv,
+)
+from kielproc.legacy_results import ResultsConfig
+
+
+def test_map_from_tot_and_static_with_dataframe(tmp_path: Path):
+    df = pd.DataFrame({
+        "p_t": [10.0, 11.0],
+        "p_s": [1.0, 1.2],
+    })
+    geom = Geometry(duct_height_m=1.0, duct_width_m=1.0, throat_diameter_m=0.1)
+    out = tmp_path / "mapped.csv"
+    res_path = map_from_tot_and_static(df, "p_t", "p_s", geom, None, out)
+    out_df = pd.read_csv(res_path)
+    assert {"qt", "dp_vent"}.issubset(out_df.columns)
+
+
+def test_translate_piccolo_with_dataframe(tmp_path: Path):
+    df = pd.DataFrame({"piccolo": [1.0, 2.0]})
+    out = tmp_path / "translated.csv"
+    res_path = translate_piccolo(df, 2.0, 1.0, "piccolo", "piccolo_translated", out)
+    out_df = pd.read_csv(res_path)
+    assert out_df["piccolo_translated"].tolist() == [3.0, 5.0]
+
+
+def test_legacy_results_from_dataframe(tmp_path: Path):
+    df = pd.DataFrame({
+        "Temperature": [20.0, 21.0],
+        "VP": [10.0, 11.0],
+        "Static": [101325.0, 101300.0],
+        "Piccolo": [12.0, 12.0],
+    })
+    cfg = ResultsConfig(static_col="Static", duct_height_m=2.0, duct_width_m=3.0)
+    out = tmp_path / "results.csv"
+    res = legacy_results_from_csv(df, cfg, out)
+    assert out.exists() and res["n_samples"] == 2

--- a/kielproc_monorepo/tests/test_legacy_results.py
+++ b/kielproc_monorepo/tests/test_legacy_results.py
@@ -36,3 +36,15 @@ def test_compute_results_area_only(tmp_path: Path):
     assert res["area_m2"] == 6.0
     assert res["duct_height_m"] is None
     assert res["duct_width_m"] is None
+
+
+def test_compute_results_dataframe():
+    df = pd.DataFrame({
+        "Temperature": [20.0, 21.0],
+        "VP": [10.0, 11.0],
+        "Static": [101325.0, 101300.0],
+        "Piccolo": [12.0, 12.0],
+    })
+    cfg = ResultsConfig(static_col="Static", duct_height_m=2.0, duct_width_m=3.0)
+    res = compute_results(df, cfg)
+    assert res["n_samples"] == 2


### PR DESCRIPTION
## Summary
- Add internal helper to convert file paths or DataFrames for GUI adapter operations
- Update mapping, translation, flow map, and results helpers to accept DataFrame input
- Extend legacy results computation to handle DataFrames directly and add tests verifying DataFrame support

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b414a1d2a48322b94867f8f7492606