### PR TITLE
Organize legacy parser outputs into user-named subfolders

### DIFF
--- a/kielproc_monorepo/tools/legacy_parser/parser_gui.py
+++ b/kielproc_monorepo/tools/legacy_parser/parser_gui.py
@@ -18,6 +18,7 @@ def main():
 
     var_xlsx = tk.StringVar()
     var_out  = tk.StringVar()
+    var_folder = tk.StringVar()
     var_thresh = tk.StringVar(value="1e-6")
 
     def pick_xlsx():
@@ -36,8 +37,11 @@ def main():
     ttk.Entry(frm, textvariable=var_out, width=70).grid(row=1, column=1, sticky="we")
     ttk.Button(frm, text="Browse…", command=pick_out).grid(row=1, column=2, padx=6)
 
-    ttk.Label(frm, text="Piccolo flat threshold (std):").grid(row=2, column=0, sticky="w")
-    ttk.Entry(frm, textvariable=var_thresh, width=20).grid(row=2, column=1, sticky="w")
+    ttk.Label(frm, text="Subfolder name:").grid(row=2, column=0, sticky="w")
+    ttk.Entry(frm, textvariable=var_folder, width=70).grid(row=2, column=1, sticky="we")
+
+    ttk.Label(frm, text="Piccolo flat threshold (std):").grid(row=3, column=0, sticky="w")
+    ttk.Entry(frm, textvariable=var_thresh, width=20).grid(row=3, column=1, sticky="w")
 
     out_text = tk.Text(root, height=24); out_text.pack(fill="both", expand=True, padx=12, pady=12)
     out_text.configure(state="disabled")
@@ -49,10 +53,20 @@ def main():
             xlsx = Path(var_xlsx.get())
             if not xlsx.exists():
                 raise FileNotFoundError(f"Workbook not found: {xlsx}")
-            outd = Path(var_out.get()) if var_out.get() else xlsx.parent/ (xlsx.stem + "_parsed")
+            base_out = Path(var_out.get()) if var_out.get() else xlsx.parent
+            folder_name = var_folder.get().strip() or f"{xlsx.stem}_parsed"
+            outd = base_out / folder_name
             outd.mkdir(parents=True, exist_ok=True)
             thresh = float(var_thresh.get())
-            summary = parse_legacy_workbook(xlsx, outd, piccolo_flat_threshold=thresh)
+            frames, summary = parse_legacy_workbook(
+                xlsx, return_mode="frames", piccolo_flat_threshold=thresh
+            )
+            for i, (port_key, df) in enumerate(frames.items(), start=1):
+                csv_path = outd / f"PORT {i}.csv"
+                df.to_csv(csv_path, index=False)
+                summary["sheets"][i-1]["csv_path"] = str(csv_path)
+            with open(outd / f"{xlsx.stem}__parse_summary.json", "w") as f:
+                json.dump(summary, f, indent=2)
             log("[OK] Parsed: " + xlsx.name)
             log(json.dumps(summary, indent=2))
             messagebox.showinfo("Parse complete", f"Parsed {xlsx.name}\nOutputs in: {outd}")
@@ -60,7 +74,7 @@ def main():
             log(f"[ERROR] {e}\n{traceback.format_exc()}")
             messagebox.showerror("Error", str(e))
 
-    ttk.Button(frm, text="Parse", command=run_parse).grid(row=3, column=1, sticky="w", pady=8)
+    ttk.Button(frm, text="Parse", command=run_parse).grid(row=4, column=1, sticky="w", pady=8)
 
     root.mainloop()
 


### PR DESCRIPTION
## Summary
- Prompt for a subfolder name in the legacy parser GUI
- Save parsed CSVs as sequential `PORT n.csv` files inside that folder and record locations in the summary

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b51527d5e0832297ac3d6a701e5078