### PR TITLE
Handle varied port CSV name formats

### DIFF
--- a/kielproc_monorepo/kielproc/cli.py
+++ b/kielproc_monorepo/kielproc/cli.py
@@ -56,7 +56,11 @@ def build_parser():
     i3.add_argument("--out", required=True)
 
     p4 = sub.add_parser("integrate-ports", help="Integrate PORT*.csv in a folder into duct results")
-    p4.add_argument("--run-dir", required=True, help="Directory containing port CSVs (filenames should include P1..P8)")
+    p4.add_argument(
+        "--run-dir",
+        required=True,
+        help="Directory containing port CSVs (filenames should include P1..P8 or PORT 1..PORT 8)",
+    )
     p4.add_argument("--duct-height", type=float, required=True)
     p4.add_argument("--duct-width", type=float, required=True)
     p4.add_argument("--baro", type=float, default=None, help="Barometric [Pa] to combine with gauge Static if Baro column absent")

--- a/kielproc_monorepo/tests/test_port_discovery.py
+++ b/kielproc_monorepo/tests/test_port_discovery.py
@@ -1,0 +1,20 @@
+import pandas as pd
+from kielproc.aggregate import integrate_run, RunConfig
+
+def _write_csv(path):
+    df = pd.DataFrame({
+        "VP": [1.0],
+        "Temperature": [20.0],
+        "Static": [101325.0],
+    })
+    df.to_csv(path, index=False)
+
+
+def test_integrate_run_port_name_variants(tmp_path):
+    names = ["P1.csv", "PORT 2.csv", "Port_3.csv", "Run07_P4.csv"]
+    for name in names:
+        _write_csv(tmp_path / name)
+    cfg = RunConfig(height_m=1.0, width_m=1.0)
+    res = integrate_run(tmp_path, cfg)
+    assert sorted(res["files"]) == sorted(names)
+    assert res["per_port"]["Port"].tolist() == ["PORT 1", "PORT 2", "PORT 3", "PORT 4"]


### PR DESCRIPTION
## Summary
- expand port file discovery to handle variants like `PORT 1.csv`, `Port_3.csv`, `Run07_P4.csv`
- normalize port keys to `PORT N` for consistent weighting
- document broadened naming in CLI help
- add regression test for port name variants

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b54934adf8832288dd29c917683622