### PR TITLE
Normalize port identifiers for weighting

### DIFF
--- a/kielproc_monorepo/kielproc/cli.py
+++ b/kielproc_monorepo/kielproc/cli.py
@@ -59,12 +59,12 @@ def build_parser():
     p4.add_argument(
         "--run-dir",
         required=True,
-        help="Directory containing port CSVs (filenames should include P1..P8 or PORT 1..PORT 8)",
+        help="Directory containing port CSVs (filenames should include P1..P8 or variants like PORT 1)",
     )
     p4.add_argument("--duct-height", type=float, required=True)
     p4.add_argument("--duct-width", type=float, required=True)
     p4.add_argument("--baro", type=float, default=None, help="Barometric [Pa] to combine with gauge Static if Baro column absent")
-    p4.add_argument("--weights-json", type=str, default=None, help='Optional JSON mapping, e.g. {"PORT 1":0.125,...}')
+    p4.add_argument("--weights-json", type=str, default=None, help='Optional JSON mapping, e.g. {"P1":0.125,...}')
     p4.add_argument("--replicate-strategy", choices=["mean","last"], default="mean")
     p4.add_argument("--area-ratio", type=float, default=None, help="Downstream-to-throat area ratio r = A_s/A_t for q_t mapping")
     p4.add_argument("--beta", type=float, default=None, help="Venturi diameter ratio β=d_t/D1 for Δp_vent estimate")

--- a/kielproc_monorepo/tests/test_port_discovery.py
+++ b/kielproc_monorepo/tests/test_port_discovery.py
@@ -1,9 +1,9 @@
 import pandas as pd
 from kielproc.aggregate import integrate_run, RunConfig
 
-def _write_csv(path):
+def _write_csv(path, vp=1.0):
     df = pd.DataFrame({
-        "VP": [1.0],
+        "VP": [vp],
         "Temperature": [20.0],
         "Static": [101325.0],
     })
@@ -17,4 +17,14 @@ def test_integrate_run_port_name_variants(tmp_path):
     cfg = RunConfig(height_m=1.0, width_m=1.0)
     res = integrate_run(tmp_path, cfg)
     assert sorted(res["files"]) == sorted(names)
-    assert res["per_port"]["Port"].tolist() == ["PORT 1", "PORT 2", "PORT 3", "PORT 4"]
+    assert res["per_port"]["Port"].tolist() == ["P1", "P2", "P3", "P4"]
+
+
+def test_integrate_run_weight_key_variants(tmp_path):
+    names = ["Run07_P1.csv", "PORT 2.csv"]
+    for name in names:
+        _write_csv(tmp_path / name)
+    cfg = RunConfig(height_m=1.0, width_m=1.0, weights={"PORT 1": 0.25, "Port_2": 0.75})
+    assert cfg.weights == {"P1": 0.25, "P2": 0.75}
+    res = integrate_run(tmp_path, cfg)
+    assert res["per_port"]["Port"].tolist() == ["P1", "P2"]


### PR DESCRIPTION
## Summary
- normalize port IDs from filenames and weight keys to canonical `P1`..`P8`
- adjust CLI help and tests for canonical port IDs

## Testing
- `nox -s tests`

------
https://chatgpt.com/codex/tasks/task_b_68b54a20d7488322892c046d98047f6b