### PR TITLE
Add absolute zero temperature checks

### DIFF
--- a/kielproc_monorepo/kielproc/aggregate.py
+++ b/kielproc_monorepo/kielproc/aggregate.py
@@ -151,7 +151,10 @@ class RunConfig:
 
 def _port_scalars_from_samples(norm: pd.DataFrame, replicate_strategy: str) -> dict:
     # per-sample density & velocity
-    T_K = norm["Temperature"].to_numpy(float) + 273.15
+    tC = norm["Temperature"].to_numpy(float)
+    if np.any(tC <= -273.15):
+        raise ValueError("Temperature at or below -273.15°C encountered")
+    T_K = tC + 273.15
     p_s = norm["Static_abs_Pa"].to_numpy(float)
     vp  = norm["VP"].to_numpy(float).clip(min=0.0)
     rho = p_s / (R * T_K)

--- a/kielproc_monorepo/kielproc/legacy_results.py
+++ b/kielproc_monorepo/kielproc/legacy_results.py
@@ -46,6 +46,8 @@ def compute_results(csv_or_df: Path | str | pd.DataFrame, cfg: ResultsConfig) ->
 
     # Temperature (°C) and Kelvin for density calc
     tC = pd.to_numeric(df.get(cfg.temp_col, pd.Series(dtype=float)), errors="coerce")
+    if (tC.notna() & (tC <= -273.15)).any():
+        raise ValueError("Temperature at or below -273.15°C encountered")
     T_K = tC + 273.15
     T_mean_K = float(np.nanmean(T_K)) if T_K.notna().any() else 293.15
     tC_mean = float(np.nanmean(tC)) if tC.notna().any() else float("nan")

--- a/kielproc_monorepo/kielproc/physics.py
+++ b/kielproc_monorepo/kielproc/physics.py
@@ -10,6 +10,8 @@ def rho_from_pT(ps_pa: np.ndarray, T_K: np.ndarray, R: float = R_SPECIFIC_AIR) -
     """
     ps_pa = np.asarray(ps_pa, dtype=float)
     T_K = np.asarray(T_K, dtype=float)
+    if np.any(T_K <= 0):
+        raise ValueError("Temperature at or below 0 K encountered")
     return ps_pa / (R * T_K)
 
 def map_qs_to_qt(qs: np.ndarray, r: float, rho_t_over_rho_s: float = 1.0) -> np.ndarray:

--- a/kielproc_monorepo/tests/test_legacy_results.py
+++ b/kielproc_monorepo/tests/test_legacy_results.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from pathlib import Path
+import pytest
 from kielproc.legacy_results import ResultsConfig, compute_results
 
 def test_compute_results_basic(tmp_path: Path):
@@ -48,3 +49,17 @@ def test_compute_results_dataframe():
     cfg = ResultsConfig(static_col="Static", duct_height_m=2.0, duct_width_m=3.0)
     res = compute_results(df, cfg)
     assert res["n_samples"] == 2
+
+
+def test_compute_results_rejects_sub_absolute_zero(tmp_path: Path):
+    df = pd.DataFrame({
+        "Temperature": [-274.0, -200.0],
+        "VP": [10.0, 11.0],
+        "Static": [101325.0, 101300.0],
+        "Piccolo": [12.0, 12.0],
+    })
+    csv = tmp_path / "bad.csv"
+    df.to_csv(csv, index=False)
+    cfg = ResultsConfig(static_col="Static", duct_height_m=1.0, duct_width_m=1.0)
+    with pytest.raises(ValueError):
+        compute_results(csv, cfg)

--- a/kielproc_monorepo/tests/test_temperature_guard.py
+++ b/kielproc_monorepo/tests/test_temperature_guard.py
@@ -1,0 +1,23 @@
+import pandas as pd
+import pytest
+import numpy as np
+from kielproc.aggregate import integrate_run, RunConfig
+from kielproc.physics import rho_from_pT
+
+
+def test_integrate_run_rejects_sub_absolute_zero(tmp_path):
+    df = pd.DataFrame({
+        "VP": [1.0],
+        "Temperature": [-300.0],
+        "Static": [101325.0],
+    })
+    csv = tmp_path / "P1.csv"
+    df.to_csv(csv, index=False)
+    cfg = RunConfig(height_m=1.0, width_m=1.0)
+    with pytest.raises(ValueError):
+        integrate_run(tmp_path, cfg)
+
+
+def test_rho_from_pT_rejects_sub_zero_kelvin():
+    with pytest.raises(ValueError):
+        rho_from_pT(np.array([101325.0]), np.array([0.0]))


### PR DESCRIPTION
## Summary
- reject temperatures at or below -273.15°C in result and integration calculations
- guard against non-physical temperatures in rho-from-pressure helper
- test temperature validation for compute_results, integrate_run, and rho_from_pT

## Testing
- `nox -s tests`

------
https://chatgpt.com/codex/tasks/task_b_68b54c07e9c88322b02c536b1b3a1d0e