### PR TITLE
Expose port file pairs from integrate_run

### DIFF
--- a/kielproc_monorepo/kielproc/cli.py
+++ b/kielproc_monorepo/kielproc/cli.py
@@ -178,12 +178,18 @@ def main(argv=None):
         res["per_port"].to_csv(outdir / "per_port.csv", index=False)
         (outdir / "duct_result.json").write_text(json.dumps(res["duct"], indent=2))
         (outdir / "normalize_meta.json").write_text(json.dumps(res["normalize_meta"], indent=2))
-        print(json.dumps({
-            "per_port_csv": str(outdir / "per_port.csv"),
-            "duct_result_json": str(outdir / "duct_result.json"),
-            "normalize_meta_json": str(outdir / "normalize_meta.json"),
-            "files_used": res["files"],
-        }, indent=2))
+        print(
+            json.dumps(
+                {
+                    "per_port_csv": str(outdir / "per_port.csv"),
+                    "duct_result_json": str(outdir / "duct_result.json"),
+                    "normalize_meta_json": str(outdir / "normalize_meta.json"),
+                    "files_used": res["files"],
+                    "pairs_used": [(pid, pf.name) for pid, pf in res.get("pairs", [])],
+                },
+                indent=2,
+            )
+        )
     elif a.cmd == "translate":
         df = pd.read_csv(a.csv)
         out = apply_translation(df, a.alpha, a.beta, src_col=a.in_col, out_col=a.out_col)

--- a/kielproc_monorepo/tests/test_port_discovery.py
+++ b/kielproc_monorepo/tests/test_port_discovery.py
@@ -18,6 +18,12 @@ def test_integrate_run_port_name_variants(tmp_path):
     res = integrate_run(tmp_path, cfg)
     assert sorted(res["files"]) == sorted(names)
     assert res["per_port"]["Port"].tolist() == ["P1", "P2", "P3", "P4"]
+    assert [(pid, pf.name) for pid, pf in res["pairs"]] == [
+        ("P1", "P1.csv"),
+        ("P2", "PORT 2.csv"),
+        ("P3", "Port_3.csv"),
+        ("P4", "Run07_P4.csv"),
+    ]
 
 
 def test_integrate_run_weight_key_variants(tmp_path):
@@ -28,3 +34,7 @@ def test_integrate_run_weight_key_variants(tmp_path):
     assert cfg.weights == {"P1": 0.25, "P2": 0.75}
     res = integrate_run(tmp_path, cfg)
     assert res["per_port"]["Port"].tolist() == ["P1", "P2"]
+    assert [(pid, pf.name) for pid, pf in res["pairs"]] == [
+        ("P1", "Run07_P1.csv"),
+        ("P2", "PORT 2.csv"),
+    ]


### PR DESCRIPTION
## Summary
- return discovered `(PortId, Path)` pairs from `integrate_run`
- surface pairs in CLI output for downstream visuals
- add tests for pair discovery

## Testing
- `PYTHONPATH=kielproc_monorepo pytest kielproc_monorepo/tests/test_port_discovery.py kielproc_monorepo/tests/test_temperature_guard.py kielproc_monorepo/tests/test_unit_aliases.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68b5542dba7c83228b6eb45f0be3f63d