### PR TITLE
feat(cli): add velocity heatmap rendering

### DIFF
--- a/kielproc/__init__.py
+++ b/kielproc/__init__.py
@@ -1,0 +1,22 @@
+"""Package redirect to monorepo implementation.
+
+This stub allows importing ``kielproc`` when running tests from the
+repository root without installing the project. It loads the actual package
+located under ``kielproc_monorepo/kielproc``.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_pkg_dir = Path(__file__).resolve().parent.parent / "kielproc_monorepo" / "kielproc"
+_spec = importlib.util.spec_from_file_location(
+    __name__,
+    _pkg_dir / "__init__.py",
+    submodule_search_locations=[str(_pkg_dir)],
+)
+_module = importlib.util.module_from_spec(_spec)
+sys.modules[__name__] = _module
+assert _spec.loader is not None
+_spec.loader.exec_module(_module)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+pythonpath = kielproc_monorepo
+# Discover tests under monorepo
+addopts = -q
+# specify tests directory
+# (some test infrastructure may require testpaths to find tests)
+testpaths = kielproc_monorepo/tests


### PR DESCRIPTION
## Summary
- expose viz flags to `integrate-ports` CLI
- optionally render velocity heatmap and include in summary output

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'kielproc')*

------
https://chatgpt.com/codex/tasks/task_b_68b555c7772483229e83ec26fd767f2b