### PR TITLE
Add FileStem to per-port CSV outputs

### DIFF
--- a/kielproc_monorepo/kielproc/aggregate.py
+++ b/kielproc_monorepo/kielproc/aggregate.py
@@ -228,6 +228,7 @@ def integrate_run(
         # plane-wise means for audit context
         rows.append({
             "Port": port_key,
+            "FileStem": pf.stem,
             "VP_pa_mean": float(pd.to_numeric(norm["VP"]).mean()),
             "T_C_mean": float(pd.to_numeric(norm["Temperature"]).mean()),
             "Static_abs_pa_mean": float(pd.to_numeric(norm["Static_abs_Pa"]).mean()),

--- a/kielproc_monorepo/tests/test_port_discovery.py
+++ b/kielproc_monorepo/tests/test_port_discovery.py
@@ -18,6 +18,7 @@ def test_integrate_run_port_name_variants(tmp_path):
     res = integrate_run(tmp_path, cfg)
     assert sorted(res["files"]) == sorted(names)
     assert res["per_port"]["Port"].tolist() == ["P1", "P2", "P3", "P4"]
+    assert res["per_port"]["FileStem"].tolist() == ["P1", "PORT 2", "Port_3", "Run07_P4"]
     assert [(pid, pf.name) for pid, pf in res["pairs"]] == [
         ("P1", "P1.csv"),
         ("P2", "PORT 2.csv"),
@@ -34,6 +35,7 @@ def test_integrate_run_weight_key_variants(tmp_path):
     assert cfg.weights == {"P1": 0.25, "P2": 0.75}
     res = integrate_run(tmp_path, cfg)
     assert res["per_port"]["Port"].tolist() == ["P1", "P2"]
+    assert res["per_port"]["FileStem"].tolist() == ["Run07_P1", "PORT 2"]
     assert [(pid, pf.name) for pid, pf in res["pairs"]] == [
         ("P1", "Run07_P1.csv"),
         ("P2", "PORT 2.csv"),


### PR DESCRIPTION
## Summary
- Include source filename stems when aggregating per-port data
- Cover FileStem column in port discovery tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b55e2e3ce88322ba0f98ac10946ba5