### PR TITLE
Handle extraneous port CSVs via parse summary and sniffing

### DIFF
--- a/kielproc_monorepo/kielproc/cli.py
+++ b/kielproc_monorepo/kielproc/cli.py
@@ -189,6 +189,8 @@ def main(argv=None):
             "files_used": res["files"],
             "pairs_used": [(pid, pf.name) for pid, pf in res.get("pairs", [])],
         }
+        if res.get("skipped"):
+            summary["skipped_files"] = [{"file": f, "reason": r} for f, r in res["skipped"]]
         if a.viz:
             from .visuals import render_velocity_heatmap
             lo, hi = (float(x) for x in a.viz_clip.split(","))


### PR DESCRIPTION
## Summary
- Improve port CSV discovery to consult `__parse_summary.json` and sniff headers, skipping non-data files
- Track skipped CSVs and expose them through `integrate_run` and CLI summary

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b566ee294483228b4c45772ab4f398