### PR TITLE
feat: sanitize headers and track replicates

### DIFF
--- a/kielproc_monorepo/tests/test_legacy_cube.py
+++ b/kielproc_monorepo/tests/test_legacy_cube.py
@@ -32,7 +32,7 @@ def test_legacy_cube_to_dataframe_handles_padding(tmp_path):
     assert ("B", 1) not in df.index
 
     # Values from the original sheets should be preserved
-    assert df.loc[("A", 0), "Static"] == 10
+    assert df.loc[("A", 0), "Static_gauge"] == 10000
     assert df.loc[("A", 1), "VP"] == 2
     assert df.loc[("B", 0), "Temperature"] == 27
     assert df.loc[("A", 1), "Time_s"] == 1.0


### PR DESCRIPTION
## Summary
- sanitize legacy sheet headers and units
- enumerate replicate groups in horizontally concatenated logs
- scale gauge static readings and convert Kelvin temps

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b60be548f883228fe67ef0732cf3dd