### PR TITLE
Enable integrator auto-discovery and plateau QA options

### DIFF
--- a/kielproc_monorepo/tests/test_fit_plateau_piccolo.py
+++ b/kielproc_monorepo/tests/test_fit_plateau_piccolo.py
@@ -1,0 +1,54 @@
+import pandas as pd
+from pathlib import Path
+
+from kielproc.cli import main as cli_main
+
+
+def test_fit_plateau_and_lag_seconds(tmp_path: Path):
+    # Good block with small variations
+    g = pd.DataFrame({
+        "mapped_ref": [100 + 0.1 * i for i in range(10)],
+        "ma": [12 + 0.01 * i for i in range(10)],
+        "pN": [100] * 10,
+        "pS": [100] * 10,
+        "pE": [100] * 10,
+        "pW": [100] * 10,
+        "q_mean": [50] * 10,
+    })
+    g_csv = tmp_path / "g.csv"
+    g.to_csv(g_csv, index=False)
+
+    # Bad block with step causing large SD/mean
+    b = pd.DataFrame({
+        "mapped_ref": [100] * 5 + [200] * 5,
+        "ma": [12] * 5 + [18] * 5,
+        "pN": [100] * 10,
+        "pS": [100] * 10,
+        "pE": [100] * 10,
+        "pW": [100] * 10,
+        "q_mean": [50] * 10,
+    })
+    b_csv = tmp_path / "b.csv"
+    b.to_csv(b_csv, index=False)
+
+    outdir = tmp_path / "out"
+    cli_main([
+        "fit",
+        "--blocks",
+        f"good={g_csv}",
+        f"bad={b_csv}",
+        "--outdir",
+        str(outdir),
+        "--sampling-hz",
+        "1",
+        "--plateau-window-s",
+        "2",
+        "--plateau-sd-frac",
+        "0.1",
+        "--piccolo-ma-col",
+        "ma",
+    ])
+
+    tbl = pd.read_csv(outdir / "alpha_beta_by_block.csv")
+    assert list(tbl["block"]) == ["good"]
+    assert "lag_seconds" in tbl.columns

--- a/kielproc_monorepo/tests/test_integrate_autodiscover.py
+++ b/kielproc_monorepo/tests/test_integrate_autodiscover.py
@@ -1,0 +1,37 @@
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from kielproc.cli import main as cli_main
+
+
+def test_integrate_autodiscover(tmp_path, monkeypatch):
+    run_dir = tmp_path
+    # create geometry and weights artifacts
+    (run_dir / "weights.json").write_text(json.dumps({"P1": 0.5}))
+    (run_dir / "geometry.json").write_text(json.dumps({"r": 2.0, "beta": 0.7}))
+
+    called = {}
+
+    def fake_integrate(run_dir_path, cfg, file_glob="*.csv", baro_cli_pa=None, area_ratio=None, beta=None):
+        called["weights"] = cfg.weights
+        called["area_ratio"] = area_ratio
+        called["beta"] = beta
+        return {"per_port": pd.DataFrame(), "duct": {}, "normalize_meta": {}, "files": [], "pairs": []}
+
+    monkeypatch.setattr("kielproc.cli.integrate_run", fake_integrate)
+
+    cli_main([
+        "integrate-ports",
+        "--run-dir",
+        str(run_dir),
+        "--duct-height",
+        "1",
+        "--duct-width",
+        "1",
+    ])
+
+    assert called["weights"] == {"P1": 0.5}
+    assert called["area_ratio"] == 2.0
+    assert called["beta"] == 0.7


### PR DESCRIPTION
## Summary
- Auto-load `weights.json` and `geometry.json` during `integrate-ports`
- Add plateau gating, sampling rate, and Piccolo mA scaling to `fit`
- Compute `lag_seconds` when sampling rate provided
- Test auto-discovery and plateau/lag options

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b60dcd92c08322ad3e71e0681d5dbd