### PR TITLE
Fix Windows installer branding for KielProc

### DIFF
--- a/tools/installer/keilproc.iss
+++ b/tools/installer/keilproc.iss
@@ -1,20 +1,20 @@
 [Setup]
-AppName=KeilProc
+AppName=KielProc
 AppVersion=0.1.0
-AppVerName=KeilProc 0.1.0
-DefaultDirName="{pf}\KeilProc"
+AppVerName=KielProc 0.1.0
+DefaultDirName="{pf}\KielProc"
 DisableDirPage=no
-DefaultGroupName=KeilProc
-OutputBaseFilename=KeilProcInstaller
+DefaultGroupName=KielProc
+OutputBaseFilename=KielProcInstaller
 Compression=lzma
 SolidCompression=yes
 
 [Files]
-Source: "..\..\kielproc_monorepo\dist\KeilProc\KeilProc.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "..\..\kielproc_monorepo\dist\KielProc\KielProc.exe"; DestDir: "{app}"; Flags: ignoreversion
 
 [Icons]
-Name: "{group}\KeilProc"; Filename: "{app}\KeilProc.exe"
-Name: "{commondesktop}\KeilProc"; Filename: "{app}\KeilProc.exe"; Tasks: desktopicon
+Name: "{group}\KielProc"; Filename: "{app}\KielProc.exe"
+Name: "{commondesktop}\KielProc"; Filename: "{app}\KielProc.exe"; Tasks: desktopicon
 
 [Tasks]
 Name: desktopicon; Description: "Create a desktop shortcut"; GroupDescription: "Additional icons:"


### PR DESCRIPTION
## Summary
- Use "KielProc" for the Windows installer name, group, and shortcuts
- Point installer to the `KielProc.exe` build output directory

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b6237ccc148322a3b1723538bbc641