### PR TITLE
Refactor legacy parser static/baro normalization

### DIFF
--- a/kielproc_monorepo/tests/test_legacy_cube.py
+++ b/kielproc_monorepo/tests/test_legacy_cube.py
@@ -32,7 +32,7 @@ def test_legacy_cube_to_dataframe_handles_padding(tmp_path):
     assert ("B", 1) not in df.index
 
     # Values from the original sheets should be preserved
-    assert df.loc[("A", 0), "Static_gauge"] == 10000
+    assert df.loc[("A", 0), "Static"] == 10
     assert df.loc[("A", 1), "VP"] == 2
     assert df.loc[("B", 0), "Temperature"] == 27
     assert df.loc[("A", 1), "Time_s"] == 1.0


### PR DESCRIPTION
## Summary
- normalize Static and Baro values using header-derived unit scales instead of magnitude heuristics
- rely on header tokens to distinguish gauge vs absolute pressures and Kelvin temperatures
- adjust legacy cube test expectations to match header-driven behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b6b17688bc83229a04208b80e3e68a