### PR TITLE
Add mouse wheel support for GUI scrollable frames

### DIFF
--- a/kielproc_monorepo/gui/app_gui.py
+++ b/kielproc_monorepo/gui/app_gui.py
@@ -24,6 +24,7 @@ from ui_polish import (
     apply_style,
     make_statusbar,
     set_grid_weights,
+    bind_mousewheel,
     tooltip,
     vcmd_float,
     labeled_row,
@@ -76,16 +77,7 @@ class ScrollableFrame(ttk.Frame):
         self.canvas.bind(
             "<Configure>", lambda e: self.canvas.itemconfig(self._win, width=e.width)
         )
-
-        def _on_mousewheel(event):
-            delta = event.delta
-            if delta == 0 and event.num in (4, 5):
-                delta = 120 if event.num == 4 else -120
-            self.canvas.yview_scroll(int(-delta / 120), "units")
-
-        self.canvas.bind_all("<MouseWheel>", _on_mousewheel)
-        self.canvas.bind_all("<Button-4>", _on_mousewheel)
-        self.canvas.bind_all("<Button-5>", _on_mousewheel)
+        bind_mousewheel(self.canvas)
 
 class App(tk.Tk):
     def __init__(self):

--- a/kielproc_monorepo/gui/duct_dp_visualizer_tk_original.py
+++ b/kielproc_monorepo/gui/duct_dp_visualizer_tk_original.py
@@ -15,6 +15,13 @@ from pathlib import Path
 import tkinter as tk
 from tkinter import ttk, filedialog, messagebox, scrolledtext
 
+# Ensure repo root is importable when running as "python gui/duct_dp_visualizer_tk_original.py"
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from ui_polish import bind_mousewheel
+
 # Try to import the analysis functions from your existing module
 Analyzer = None
 _module_err = None
@@ -50,16 +57,7 @@ class ScrollableFrame(ttk.Frame):
         self._win = self.canvas.create_window((0, 0), window=self.inner, anchor="nw")
         self.inner.bind("<Configure>", lambda e: self.canvas.configure(scrollregion=self.canvas.bbox("all")))
         self.canvas.bind("<Configure>", lambda e: self.canvas.itemconfig(self._win, width=e.width))
-
-        def _on_mousewheel(event):
-            delta = event.delta
-            if delta == 0 and event.num in (4, 5):
-                delta = 120 if event.num == 4 else -120
-            self.canvas.yview_scroll(int(-delta / 120), "units")
-
-        self.canvas.bind_all("<MouseWheel>", _on_mousewheel)
-        self.canvas.bind_all("<Button-4>", _on_mousewheel)
-        self.canvas.bind_all("<Button-5>", _on_mousewheel)
+        bind_mousewheel(self.canvas)
 
 
 class App(tk.Tk):

--- a/kielproc_monorepo/ui_polish.py
+++ b/kielproc_monorepo/ui_polish.py
@@ -40,6 +40,21 @@ def set_grid_weights(widget: tk.Widget, rows: int, cols: int) -> None:
         widget.columnconfigure(c, weight=1)
 
 
+def bind_mousewheel(widget: tk.Widget) -> None:
+    """Enable basic mouse wheel scrolling on *widget* across platforms."""
+
+    def _on_mousewheel(event):
+        delta = event.delta
+        if delta == 0 and event.num in (4, 5):
+            delta = 120 if event.num == 4 else -120
+        widget.yview_scroll(int(-delta / 120), "units")
+
+    widget.bind("<Enter>", lambda _: widget.focus_set())
+    widget.bind("<MouseWheel>", _on_mousewheel)
+    widget.bind("<Button-4>", _on_mousewheel)
+    widget.bind("<Button-5>", _on_mousewheel)
+
+
 def tooltip(widget: tk.Widget, text: str) -> None:
     """Attach a very small tooltip to *widget*."""
     tip = {"window": None}


### PR DESCRIPTION
## Summary
- add reusable `bind_mousewheel` helper for Tk widgets
- enable mouse wheel scrolling in GUI `ScrollableFrame` containers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b94489a6a08322a24f765d5768f9b0