### PR TITLE
Fix fs handling in legacy processing GUI

### DIFF
--- a/kielproc_monorepo/gui/app_gui.py
+++ b/kielproc_monorepo/gui/app_gui.py
@@ -931,7 +931,8 @@ class App(tk.Tk):
             geom = self._get_geometry()
             outdir = Path(self.var_outdir.get()); outdir.mkdir(parents=True, exist_ok=True)
             out = outdir / "legacy_qs_qp_dpvent.csv"
-            fs = float(self.var_fs.get()) if self.var_fs.get().strip() else None
+            fs_val = self.var_fs.get()
+            fs = float(fs_val) if fs_val > 0 else None
             wrote, df = process_legacy_parsed_csv(
                 Path(self.var_legacy_csv.get()),
                 geom,


### PR DESCRIPTION
## Summary
- prevent `float` objects from calling `strip` when processing legacy data by checking numeric value instead

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b954cb6be88322860ca6ddd88946f9