### PR TITLE
Preserve legacy parser inputs

### DIFF
--- a/kielproc_monorepo/tests/test_legacy_parser_temp_copy.py
+++ b/kielproc_monorepo/tests/test_legacy_parser_temp_copy.py
@@ -1,0 +1,32 @@
+import hashlib
+from pathlib import Path
+
+import pandas as pd
+
+from tools.legacy_parser.legacy_parser.parser import parse_legacy_workbook
+
+
+def _file_hash(p: Path) -> str:
+    h = hashlib.sha256()
+    h.update(p.read_bytes())
+    return h.hexdigest()
+
+
+def test_parser_preserves_original_workbook(tmp_path):
+    """The legacy parser should not modify the source workbook."""
+    # Create a minimal workbook with one sheet
+    path = tmp_path / "wb.xlsx"
+    rows = [
+        ["Time", "Static pressure", "Velocity pressure", "Duct air temperature", "Piccolo current"],
+        ["s", "Pa", "Pa", "C", "mA"],
+        ["2020-01-01 00:00:00", 10, 1, 25, 5],
+    ]
+    with pd.ExcelWriter(path) as writer:
+        pd.DataFrame(rows).to_excel(writer, sheet_name="A", header=False, index=False)
+
+    before = _file_hash(path)
+    out_dir = tmp_path / "out"
+    parse_legacy_workbook(path, out_dir=out_dir, return_mode="files")
+
+    assert path.exists()
+    assert _file_hash(path) == before

--- a/kielproc_monorepo/tools/legacy_parser/legacy_parser/parser.py
+++ b/kielproc_monorepo/tools/legacy_parser/legacy_parser/parser.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, asdict
 from pathlib import Path
 import pandas as pd
 import numpy as np
-import re, json, math
+import re, json, math, shutil, tempfile
 from typing import Optional, List
 
 NUMERIC_FIELDS_CANON = ["Static", "Static_gauge", "VP", "Temperature", "Piccolo"]
@@ -158,212 +158,128 @@ def parse_legacy_workbook(
         assert out_dir is not None, "out_dir is required when return_mode='files'"
         out_dir = Path(out_dir)
         out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Work on a temporary copy so the original workbook is never modified.
+    temp_path: Path | None = None
+    xl = None
     try:
-        xl = pd.ExcelFile(xlsx_path)
+        with tempfile.NamedTemporaryFile(suffix=xlsx_path.suffix, delete=False) as tmp:
+            temp_path = Path(tmp.name)
+        shutil.copy2(xlsx_path, temp_path)
+        xl = pd.ExcelFile(temp_path)
     except ImportError as exc:  # pragma: no cover - depends on optional deps
+        if temp_path and temp_path.exists():
+            try:
+                temp_path.unlink()
+            except Exception:
+                pass
         raise ImportError("Unable to open workbook. For .xls files install 'xlrd'.") from exc
     results: List[SheetParseResult] = []
     frames: dict[str, pd.DataFrame] = {}
 
-    for sheet in xl.sheet_names:
-        try:
-            raw = xl.parse(sheet, header=None)
-        except Exception:
-            continue
-        header_row = None; unit_row = None
-        for i in range(min(15, len(raw))):
-            row = [_clean_name(v) for v in raw.iloc[i].tolist()]
-            if "static pressure" in row and "velocity pressure" in row:
-                header_row = i
-                unit_row = i+1 if i+1 < len(raw) else None
-                break
-
-        piccolo_flat = False; notes = ""
-
-        if header_row is not None:
-            header_cells = [_clean_name(v) for v in raw.iloc[header_row].tolist()]
-            time_positions = [j for j,v in enumerate(header_cells) if v == "time"]
-
-            if len(time_positions) <= 1:
-                # 2018-style vertical
-                cols = raw.iloc[header_row].astype(str).tolist()
-                units = raw.iloc[unit_row].astype(str).tolist() if unit_row is not None else [None]*len(cols)
-                newcols = []
-                for n,u in zip(cols, units):
-                    n = str(n).strip()
-                    if u not in (None, "", float("nan")):
-                        newcols.append(f"{n} ({str(u).strip()})")
-                    else:
-                        newcols.append(n)
-                df = xl.parse(sheet, header=header_row)
-                df.columns = newcols[:len(df.columns)]
-                if "Time" in df.columns:
-                    mask = df["Time"].astype(str).map(_clean_name)
-                    # Drop rows where the time column is empty, a header repeat, or an
-                    # averages row.  ``_clean_name`` normalizes case/whitespace so we
-                    # can simply test prefixes for robustness (e.g. "Averages:").
-                    drop_time = mask.isin(['', 'nan']) | mask.str.contains(r"^(?:time|averages?)", na=False)
-                    df = df[~drop_time].copy()
-
-                # Remove any rows that are entirely header labels or contain the word
-                # "averages" in any column.  This handles cases where a header row
-                # leaks into the body of the sheet.
-                clean_rows = df.applymap(_clean_name)
-                hdr_clean = [_clean_name(c) for c in df.columns]
-                bad = clean_rows.apply(
-                    lambda r: r.eq('averages').any() or
-                               all((v == '' or v == h) for v, h in zip(r, hdr_clean)),
-                    axis=1,
-                )
-                df = df[~bad].copy()
-
-                out = pd.DataFrame(index=df.index)
-
-                def first_match(patterns):
-                    for p in patterns:
-                        for c in df.columns:
-                            if re.search(p, str(c), flags=re.I):
-                                return c
-                    return None
-
-                m_time = first_match([r"^time(?!.*unit)"])
-                m_static = first_match([r"static pressure"])
-                m_vp = first_match([r"velocity pressure"])
-                m_temp = first_match([r"duct air temperature|temperature"])
-                m_picc = first_match([r"piccolo.*current|piccolo.*dp|throat.*dp"])
-
-                if m_time: out["Time"] = df[m_time]
-                if m_static: out["Static"] = df[m_static]
-                if m_vp: out["VP"] = df[m_vp]
-                if m_temp: out["Temperature"] = df[m_temp]
-                if m_picc: out["Piccolo"] = df[m_picc]
-
-                out = _sanitize_headers_and_units(out)
-                key_cols = [c for c in ["Static", "VP", "Temperature", "Piccolo"] if c in out.columns]
-                if key_cols:
-                    # Coerce to numeric so that any leaked headers or text such as
-                    # "Averages" become NaN prior to the emptiness check.
-                    for c in key_cols:
-                        out[c] = pd.to_numeric(out[c], errors="coerce")
-                    mask_all_nan = out[key_cols].isna().all(axis=1)
-                    out = out[~mask_all_nan]
-                out = out.copy()
-                # Write a numeric replicate index:
-                #  - Vertical P1..P8 sheets keep their sheet-suffix replicate if present
-                #  - Horizontal concatenation: each discovered column-group becomes a replicate
-                out.insert(0, "Sample", range(1, len(out)+1))
-                out["Workbook"] = xlsx_path.name
-                out["Sheet"] = sheet
-                m = re.search(r"(\.\d+)$", sheet)
-                replicate = m.group(1) if m else None
-                out["Replicate"] = replicate or ""
-
-                if "Piccolo" in out.columns:
-                    v = out["Piccolo"].to_numpy(float)
-                    piccolo_flat = bool(np.nanstd(v) < piccolo_flat_threshold)
-
-                missing = _missing_required(out)
-                if missing:
-                    notes = f"missing required columns: {', '.join(missing)}"
-
-                port_key = sheet if replicate is None else f"{sheet}__{replicate}"
-                frames[port_key] = out
-
-                if return_mode == "files":
-                    csv_path = Path(out_dir) / f"{xlsx_path.stem}__{re.sub(r'[^A-Za-z0-9_.-]+','_', port_key)}.csv"
-                    out.to_csv(csv_path, index=False)
-                    results.append(
-                        SheetParseResult(
-                            sheet=sheet,
-                            replicate=replicate,
-                            csv_path=str(csv_path),
-                            n_rows=int(len(out)),
-                            n_cols=int(out.shape[1]),
-                            piccolo_flat=piccolo_flat,
-                            mode="vertical",
-                            notes=notes,
-                        )
-                    )
-                else:
-                    results.append(
-                        SheetParseResult(
-                            sheet=sheet,
-                            replicate=replicate,
-                            csv_path=None,
-                            n_rows=int(len(out)),
-                            n_cols=int(out.shape[1]),
-                            piccolo_flat=piccolo_flat,
-                            mode="vertical",
-                            notes=notes,
-                        )
-                    )
+    try:
+        for sheet in xl.sheet_names:
+            try:
+                raw = xl.parse(sheet, header=None)
+            except Exception:
                 continue
+            header_row = None; unit_row = None
+            for i in range(min(15, len(raw))):
+                row = [_clean_name(v) for v in raw.iloc[i].tolist()]
+                if "static pressure" in row and "velocity pressure" in row:
+                    header_row = i
+                    unit_row = i+1 if i+1 < len(raw) else None
+                    break
 
-            else:
-                # 2007-style multiport
-                headers = raw.iloc[header_row].astype(str).tolist()
-                group_starts = [j for j,h in enumerate(headers) if _clean_name(h) == "time"]
-                group_starts.append(len(headers))
-                rows_acc = []
-                data_start = (unit_row or header_row) + 1
+            piccolo_flat = False; notes = ""
 
-                # When columns repeat horizontally (Time/Static/VP again), treat each group as Replicate=1,2,...
-                for rep_idx, (a,b) in enumerate(zip(group_starts[:-1], group_starts[1:]), start=1):
-                    sub_hdr = headers[a:b]
-                    port_val = None
-                    for off in range(0, min(5, len(sub_hdr))):
-                        cell = raw.iloc[0, a+off] if (a+off) < raw.shape[1] else None
-                        try:
-                            pv = float(cell)
-                            if not math.isnan(pv):
-                                port_val = pv; break
-                        except Exception:
-                            continue
-                    for r in range(data_start, len(raw)):
-                        vals = raw.iloc[r, a:b]
-                        if pd.isna(vals).all():
-                            continue
-                        if any(_clean_name(v).startswith('average') for v in vals.values):
-                            continue
-                        rec = {"Sample": r - data_start + 1, "Workbook": xlsx_path.name, "Sheet": sheet, "Replicate": rep_idx}
-                        rec["Port"] = port_val
-                        names = [str(n).strip().lower() for n in raw.iloc[header_row, a:b]]
-                        for j,name in enumerate(names):
-                            v = vals.iloc[j]
-                            if name == "time":
-                                rec["Time"] = v
-                            elif "static pressure" in name:
-                                rec["Static"] = v
-                            elif "velocity pressure" in name:
-                                rec["VP"] = v
-                            elif "duct air temperature" in name:
-                                rec["Temperature"] = v
-                            elif "piccolo" in name:
-                                rec["Piccolo"] = v
-                        tval = _clean_name(rec.get('Time', ''))
-                        if tval in ('', 'nan') or tval.startswith('time') or tval.startswith('average'):
-                            continue
-                        rows_acc.append(rec)
+            if header_row is not None:
+                header_cells = [_clean_name(v) for v in raw.iloc[header_row].tolist()]
+                time_positions = [j for j,v in enumerate(header_cells) if v == "time"]
 
-                if rows_acc:
-                    out = pd.DataFrame(rows_acc)
+                if len(time_positions) <= 1:
+                    # 2018-style vertical
+                    cols = raw.iloc[header_row].astype(str).tolist()
+                    units = raw.iloc[unit_row].astype(str).tolist() if unit_row is not None else [None]*len(cols)
+                    newcols = []
+                    for n,u in zip(cols, units):
+                        n = str(n).strip()
+                        if u not in (None, "", float("nan")):
+                            newcols.append(f"{n} ({str(u).strip()})")
+                        else:
+                            newcols.append(n)
+                    df = xl.parse(sheet, header=header_row)
+                    df.columns = newcols[:len(df.columns)]
+                    if "Time" in df.columns:
+                        mask = df["Time"].astype(str).map(_clean_name)
+                        # Drop rows where the time column is empty, a header repeat, or an
+                        # averages row.  ``_clean_name`` normalizes case/whitespace so we
+                        # can simply test prefixes for robustness (e.g. "Averages:").
+                        drop_time = mask.isin(['', 'nan']) | mask.str.contains(r"^(?:time|averages?)", na=False)
+                        df = df[~drop_time].copy()
+
+                    # Remove any rows that are entirely header labels or contain the word
+                    # "averages" in any column.  This handles cases where a header row
+                    # leaks into the body of the sheet.
+                    clean_rows = df.applymap(_clean_name)
+                    hdr_clean = [_clean_name(c) for c in df.columns]
+                    bad = clean_rows.apply(
+                        lambda r: r.eq('averages').any() or
+                                   all((v == '' or v == h) for v, h in zip(r, hdr_clean)),
+                        axis=1,
+                    )
+                    df = df[~bad].copy()
+
+                    out = pd.DataFrame(index=df.index)
+
+                    def first_match(patterns):
+                        for p in patterns:
+                            for c in df.columns:
+                                if re.search(p, str(c), flags=re.I):
+                                    return c
+                        return None
+
+                    m_time = first_match([r"^time(?!.*unit)"])
+                    m_static = first_match([r"static pressure"])
+                    m_vp = first_match([r"velocity pressure"])
+                    m_temp = first_match([r"duct air temperature|temperature"])
+                    m_picc = first_match([r"piccolo.*current|piccolo.*dp|throat.*dp"])
+
+                    if m_time: out["Time"] = df[m_time]
+                    if m_static: out["Static"] = df[m_static]
+                    if m_vp: out["VP"] = df[m_vp]
+                    if m_temp: out["Temperature"] = df[m_temp]
+                    if m_picc: out["Piccolo"] = df[m_picc]
+
                     out = _sanitize_headers_and_units(out)
                     key_cols = [c for c in ["Static", "VP", "Temperature", "Piccolo"] if c in out.columns]
                     if key_cols:
+                        # Coerce to numeric so that any leaked headers or text such as
+                        # "Averages" become NaN prior to the emptiness check.
                         for c in key_cols:
                             out[c] = pd.to_numeric(out[c], errors="coerce")
                         mask_all_nan = out[key_cols].isna().all(axis=1)
                         out = out[~mask_all_nan]
+                    out = out.copy()
+                    # Write a numeric replicate index:
+                    #  - Vertical P1..P8 sheets keep their sheet-suffix replicate if present
+                    #  - Horizontal concatenation: each discovered column-group becomes a replicate
+                    out.insert(0, "Sample", range(1, len(out)+1))
+                    out["Workbook"] = xlsx_path.name
+                    out["Sheet"] = sheet
+                    m = re.search(r"(\.\d+)$", sheet)
+                    replicate = m.group(1) if m else None
+                    out["Replicate"] = replicate or ""
+
                     if "Piccolo" in out.columns:
                         v = out["Piccolo"].to_numpy(float)
                         piccolo_flat = bool(np.nanstd(v) < piccolo_flat_threshold)
 
                     missing = _missing_required(out)
-                    note = ""
                     if missing:
-                        note = f"missing required columns: {', '.join(missing)}"
+                        notes = f"missing required columns: {', '.join(missing)}"
 
-                    port_key = sheet
+                    port_key = sheet if replicate is None else f"{sheet}__{replicate}"
                     frames[port_key] = out
 
                     if return_mode == "files":
@@ -372,58 +288,166 @@ def parse_legacy_workbook(
                         results.append(
                             SheetParseResult(
                                 sheet=sheet,
-                                replicate=None,
+                                replicate=replicate,
                                 csv_path=str(csv_path),
                                 n_rows=int(len(out)),
                                 n_cols=int(out.shape[1]),
                                 piccolo_flat=piccolo_flat,
-                                mode="multiport",
-                                notes=note,
+                                mode="vertical",
+                                notes=notes,
                             )
                         )
                     else:
                         results.append(
                             SheetParseResult(
                                 sheet=sheet,
-                                replicate=None,
+                                replicate=replicate,
                                 csv_path=None,
                                 n_rows=int(len(out)),
                                 n_cols=int(out.shape[1]),
                                 piccolo_flat=piccolo_flat,
-                                mode="multiport",
-                                notes=note,
+                                mode="vertical",
+                                notes=notes,
                             )
                         )
                     continue
 
-        # Fallback: minimal CSV
-        out = pd.DataFrame({"Sample": range(1, len(raw)+1)})
-        out["Workbook"] = xlsx_path.name; out["Sheet"] = sheet; out["Replicate"] = ""
-        port_key = sheet
-        frames[port_key] = out
+                else:
+                    # 2007-style multiport
+                    headers = raw.iloc[header_row].astype(str).tolist()
+                    group_starts = [j for j,h in enumerate(headers) if _clean_name(h) == "time"]
+                    group_starts.append(len(headers))
+                    rows_acc = []
+                    data_start = (unit_row or header_row) + 1
+
+                    # When columns repeat horizontally (Time/Static/VP again), treat each group as Replicate=1,2,...
+                    for rep_idx, (a,b) in enumerate(zip(group_starts[:-1], group_starts[1:]), start=1):
+                        sub_hdr = headers[a:b]
+                        port_val = None
+                        for off in range(0, min(5, len(sub_hdr))):
+                            cell = raw.iloc[0, a+off] if (a+off) < raw.shape[1] else None
+                            try:
+                                pv = float(cell)
+                                if not math.isnan(pv):
+                                    port_val = pv; break
+                            except Exception:
+                                continue
+                        for r in range(data_start, len(raw)):
+                            vals = raw.iloc[r, a:b]
+                            if pd.isna(vals).all():
+                                continue
+                            if any(_clean_name(v).startswith('average') for v in vals.values):
+                                continue
+                            rec = {"Sample": r - data_start + 1, "Workbook": xlsx_path.name, "Sheet": sheet, "Replicate": rep_idx}
+                            rec["Port"] = port_val
+                            names = [str(n).strip().lower() for n in raw.iloc[header_row, a:b]]
+                            for j,name in enumerate(names):
+                                v = vals.iloc[j]
+                                if name == "time":
+                                    rec["Time"] = v
+                                elif "static pressure" in name:
+                                    rec["Static"] = v
+                                elif "velocity pressure" in name:
+                                    rec["VP"] = v
+                                elif "duct air temperature" in name:
+                                    rec["Temperature"] = v
+                                elif "piccolo" in name:
+                                    rec["Piccolo"] = v
+                            tval = _clean_name(rec.get('Time', ''))
+                            if tval in ('', 'nan') or tval.startswith('time') or tval.startswith('average'):
+                                continue
+                            rows_acc.append(rec)
+
+                    if rows_acc:
+                        out = pd.DataFrame(rows_acc)
+                        out = _sanitize_headers_and_units(out)
+                        key_cols = [c for c in ["Static", "VP", "Temperature", "Piccolo"] if c in out.columns]
+                        if key_cols:
+                            for c in key_cols:
+                                out[c] = pd.to_numeric(out[c], errors="coerce")
+                            mask_all_nan = out[key_cols].isna().all(axis=1)
+                            out = out[~mask_all_nan]
+                        if "Piccolo" in out.columns:
+                            v = out["Piccolo"].to_numpy(float)
+                            piccolo_flat = bool(np.nanstd(v) < piccolo_flat_threshold)
+
+                        missing = _missing_required(out)
+                        note = ""
+                        if missing:
+                            note = f"missing required columns: {', '.join(missing)}"
+
+                        port_key = sheet
+                        frames[port_key] = out
+
+                        if return_mode == "files":
+                            csv_path = Path(out_dir) / f"{xlsx_path.stem}__{re.sub(r'[^A-Za-z0-9_.-]+','_', port_key)}.csv"
+                            out.to_csv(csv_path, index=False)
+                            results.append(
+                                SheetParseResult(
+                                    sheet=sheet,
+                                    replicate=None,
+                                    csv_path=str(csv_path),
+                                    n_rows=int(len(out)),
+                                    n_cols=int(out.shape[1]),
+                                    piccolo_flat=piccolo_flat,
+                                    mode="multiport",
+                                    notes=note,
+                                )
+                            )
+                        else:
+                            results.append(
+                                SheetParseResult(
+                                    sheet=sheet,
+                                    replicate=None,
+                                    csv_path=None,
+                                    n_rows=int(len(out)),
+                                    n_cols=int(out.shape[1]),
+                                    piccolo_flat=piccolo_flat,
+                                    mode="multiport",
+                                    notes=note,
+                                )
+                            )
+                        continue
+
+            # Fallback: minimal CSV
+            out = pd.DataFrame({"Sample": range(1, len(raw)+1)})
+            out["Workbook"] = xlsx_path.name; out["Sheet"] = sheet; out["Replicate"] = ""
+            port_key = sheet
+            frames[port_key] = out
+            if return_mode == "files":
+                csv_path = Path(out_dir) / f"{xlsx_path.stem}__{re.sub(r'[^A-Za-z0-9_.-]+','_', port_key)}.csv"
+                out.to_csv(csv_path, index=False)
+                results.append(SheetParseResult(sheet=sheet, replicate=None, csv_path=str(csv_path),
+                                                n_rows=int(len(out)), n_cols=int(out.shape[1]),
+                                                piccolo_flat=False, mode="fallback", notes="no recognizable headers"))
+            else:
+                results.append(SheetParseResult(sheet=sheet, replicate=None, csv_path=None,
+                                                n_rows=int(len(out)), n_cols=int(out.shape[1]),
+                                                piccolo_flat=False, mode="fallback", notes="no recognizable headers"))
+
+        summary = {"workbook": xlsx_path.name, "sheets": [asdict(r) for r in results]}
+
         if return_mode == "files":
-            csv_path = Path(out_dir) / f"{xlsx_path.stem}__{re.sub(r'[^A-Za-z0-9_.-]+','_', port_key)}.csv"
-            out.to_csv(csv_path, index=False)
-            results.append(SheetParseResult(sheet=sheet, replicate=None, csv_path=str(csv_path),
-                                            n_rows=int(len(out)), n_cols=int(out.shape[1]),
-                                            piccolo_flat=False, mode="fallback", notes="no recognizable headers"))
-        else:
-            results.append(SheetParseResult(sheet=sheet, replicate=None, csv_path=None,
-                                            n_rows=int(len(out)), n_cols=int(out.shape[1]),
-                                            piccolo_flat=False, mode="fallback", notes="no recognizable headers"))
+            with open(Path(out_dir) / f"{xlsx_path.stem}__parse_summary.json", "w") as f:
+                json.dump(summary, f, indent=2, default=str)
+            return summary
 
-    summary = {"workbook": xlsx_path.name, "sheets": [asdict(r) for r in results]}
+        if return_mode == "frames":
+            return frames, summary
 
-    if return_mode == "files":
-        with open(Path(out_dir) / f"{xlsx_path.stem}__parse_summary.json", "w") as f:
-            json.dump(summary, f, indent=2, default=str)
-        return summary
+        if return_mode == "array":
+            cube = _frames_to_cube(xlsx_path.name, frames)
+            return cube, summary
 
-    if return_mode == "frames":
-        return frames, summary
-
-    if return_mode == "array":
-        cube = _frames_to_cube(xlsx_path.name, frames)
-        return cube, summary
-
-    raise ValueError(f"Unknown return_mode={return_mode!r}")
+        raise ValueError(f"Unknown return_mode={return_mode!r}")
+    finally:
+        if xl is not None:
+            try:
+                xl.close()
+            except Exception:
+                pass
+        if temp_path and temp_path.exists():
+            try:
+                temp_path.unlink()
+            except Exception:
+                pass


### PR DESCRIPTION
## Summary
- avoid mutating input workbooks by parsing a temporary copy of the file
- add regression test ensuring the original workbook remains intact

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b966d97254832295ac560cfe8968c8