### PR TITLE
Handle blank alpha/beta in GUI translation

### DIFF
--- a/kielproc_monorepo/gui/app_gui.py
+++ b/kielproc_monorepo/gui/app_gui.py
@@ -59,6 +59,33 @@ from kielproc.geometry import (
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 
 
+def _float_or_zero(value: str, default: float = 0.0) -> float:
+    """Convert *value* to float, returning *default* when empty.
+
+    Parameters
+    ----------
+    value:
+        The string representation of the float value.  If ``value`` is an
+        empty string, *default* is returned instead of raising ``ValueError``.
+    default:
+        The value to use when ``value`` is empty.  Defaults to 0.0.
+
+    Returns
+    -------
+    float
+        The converted floating point number.
+
+    Raises
+    ------
+    ValueError
+        If ``value`` is non-empty and cannot be converted to float.
+    """
+
+    if value == "":
+        return default
+    return float(value)
+
+
 class ScrollableFrame(ttk.Frame):
     """A simple scrollable frame container using a canvas and vertical scrollbar."""
 
@@ -1051,8 +1078,16 @@ class App(tk.Tk):
     def _do_translate(self):
         try:
             out = Path(self.var_outdir.get())/"translated.csv"
-            res = translate_piccolo(Path(self.var_tr_csv.get()), float(self.var_alpha.get()),
-                                    float(self.var_beta.get()), self.var_piccol.get(), "piccolo_translated", out)
+            alpha = _float_or_zero(self.var_alpha.get())
+            beta = _float_or_zero(self.var_beta.get())
+            res = translate_piccolo(
+                Path(self.var_tr_csv.get()),
+                alpha,
+                beta,
+                self.var_piccol.get(),
+                "piccolo_translated",
+                out,
+            )
             self.log(f"[OK] Wrote {res}")
         except Exception as e:
             self.log(f"[ERROR] translate: {e}\n{traceback.format_exc()}")

--- a/kielproc_monorepo/tests/test_app_gui_utils.py
+++ b/kielproc_monorepo/tests/test_app_gui_utils.py
@@ -1,0 +1,15 @@
+import pytest
+from gui.app_gui import _float_or_zero
+
+
+def test_float_or_zero_with_number():
+    assert _float_or_zero("1.5") == 1.5
+
+
+def test_float_or_zero_with_empty_string():
+    assert _float_or_zero("") == 0.0
+
+
+def test_float_or_zero_invalid_raises():
+    with pytest.raises(ValueError):
+        _float_or_zero("abc")


### PR DESCRIPTION
## Summary
- avoid ValueError when alpha or beta fields are left blank in GUI translation by introducing `_float_or_zero`
- add tests for `_float_or_zero` helper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b96cd508a08322a5206b6da08cc5e6