### PR TITLE
Add Run Easy orchestrator and CLI

### DIFF
--- a/kielproc_monorepo/kielproc/run_easy.py
+++ b/kielproc_monorepo/kielproc/run_easy.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+"""Lightweight façade for the "Run Easy" one-click processor.
+
+This module defines a small orchestrator that sequences the legacy
+processing pipeline steps.  It intentionally avoids pulling in the heavy
+implementation details from the monorepo; the individual step methods are
+thin placeholders which will be wired up to the real logic in future
+iterations.  For now they allow the control-flow and error-handling to be
+exercised in isolation.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Dict
+import json
+import time
+
+NZT = "Pacific/Auckland"
+
+
+@dataclass
+class SitePreset:
+    """Bundle geometry/instrument defaults for a measurement site."""
+
+    name: str
+    geometry: dict
+    instruments: dict
+    defaults: dict
+
+
+@dataclass
+class RunInputs:
+    """Inputs required to run the one-click pipeline."""
+
+    src: Path
+    site: SitePreset
+    baro_override_Pa: Optional[float] = None
+    run_stamp: Optional[str] = None  # YYYYMMDD_HHMM in NZT
+
+
+class OneClickError(Exception):
+    """Raised when a hard failure occurs during the one-click run."""
+
+
+class Orchestrator:
+    """Coordinate parse → integrate → map → fit → translate → report."""
+
+    def __init__(self, run: RunInputs):
+        self.run = run
+        self.artifacts: Dict[str, Path] = {}
+        self.summary: Dict = {"warnings": [], "errors": []}
+
+    # --- helpers -----------------------------------------------------
+    def _stamp(self) -> str:
+        if self.run.run_stamp:
+            return self.run.run_stamp
+        # Assume system clock already set to NZT to avoid tz deps.
+        return time.strftime("%Y%m%d_%H%M")
+
+    def _mkdirs(self, base: Path) -> Dict[str, Path]:
+        base.mkdir(parents=True, exist_ok=True)
+        ports = base / "ports_csv"
+        ports.mkdir(exist_ok=True)
+        return {"base": base, "ports": ports}
+
+    # --- pipeline stages ---------------------------------------------
+    def preflight(self) -> None:
+        src = self.run.src
+        if not src.exists():
+            raise OneClickError(f"Input not found: {src}")
+        if src.is_dir():
+            wb = [p for p in src.iterdir() if p.suffix.lower() in {".xlsx", ".xls"}]
+            if not wb:
+                raise OneClickError("No legacy workbooks found in directory.")
+        else:
+            if src.suffix.lower() not in {".xlsx", ".xls"}:
+                raise OneClickError("Legacy workbook must be .xlsx/.xls")
+        if self.run.baro_override_Pa is not None and self.run.baro_override_Pa <= 0:
+            raise OneClickError("Barometric override must be > 0 Pa")
+
+    def parse(self, ports_dir: Path) -> None:  # pragma: no cover - placeholder
+        """Parse legacy workbooks to per-port CSVs."""
+        pass
+
+    def integrate(self, base_dir: Path) -> None:  # pragma: no cover - placeholder
+        """Integrate per-port files into duct aggregates."""
+        pass
+
+    def map(self, base_dir: Path) -> None:  # pragma: no cover - placeholder
+        """Build velocity maps from integrated data."""
+        pass
+
+    def fit(self, base_dir: Path) -> None:  # pragma: no cover - placeholder
+        """Fit calibration models."""
+        pass
+
+    def translate(self, base_dir: Path) -> None:  # pragma: no cover - placeholder
+        """Generate control-system lookup tables."""
+        pass
+
+    def report(self, base_dir: Path) -> None:  # pragma: no cover - placeholder
+        """Emit consolidated HTML/PDF reports."""
+        pass
+
+    # --- public ------------------------------------------------------
+    def run_all(self) -> Path:
+        """Execute the full one-click pipeline and return the run directory."""
+        self.preflight()
+        stamp = self._stamp()
+        out = Path(f"RUN_{stamp}")
+        dirs = self._mkdirs(out)
+        # persist run context for audit
+        (out / "run_context.json").write_text(
+            json.dumps(
+                {
+                    "site": self.run.site.name,
+                    "baro_override_Pa": self.run.baro_override_Pa,
+                    "stamp": stamp,
+                    "timezone": NZT,
+                },
+                indent=2,
+            )
+        )
+        self.parse(dirs["ports"])
+        self.integrate(out)
+        self.map(out)
+        self.fit(out)
+        self.translate(out)
+        self.report(out)
+        return out
+
+
+# Convenience entry point -----------------------------------------------------
+
+def run_easy_legacy(
+    src: Path,
+    site: SitePreset,
+    baro_override_Pa: Optional[float] = None,
+    run_stamp: Optional[str] = None,
+) -> Path:
+    """Run the full pipeline for a legacy workbook using ``SitePreset`` defaults."""
+
+    run = RunInputs(src=src, site=site, baro_override_Pa=baro_override_Pa, run_stamp=run_stamp)
+    return Orchestrator(run).run_all()

--- a/kielproc_monorepo/tests/test_cli_one_click.py
+++ b/kielproc_monorepo/tests/test_cli_one_click.py
@@ -1,0 +1,20 @@
+import json
+from pathlib import Path
+
+from kielproc import cli
+
+
+def test_cli_one_click(monkeypatch, tmp_path, capsys):
+    out_dir = tmp_path / "out"
+
+    def fake_run(src, site, baro_override_Pa=None, run_stamp=None):
+        assert src == Path(tmp_path / "book.xlsx")
+        return out_dir
+
+    monkeypatch.setattr(cli, "run_easy_legacy", fake_run)
+    args = ["one-click", str(tmp_path / "book.xlsx"), "--site", "DefaultSite"]
+    cli.main(args)
+    captured = capsys.readouterr().out.strip()
+    data = json.loads(captured)
+    assert data["ok"] is True
+    assert data["out_dir"] == str(out_dir)

--- a/kielproc_monorepo/tests/test_run_easy_orchestrator.py
+++ b/kielproc_monorepo/tests/test_run_easy_orchestrator.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+from kielproc.run_easy import Orchestrator, RunInputs, SitePreset
+
+
+def test_run_all_sequences_steps(tmp_path, monkeypatch):
+    preset = SitePreset(name="T", geometry={}, instruments={}, defaults={})
+    src = tmp_path / "book.xlsx"
+    src.write_text("dummy")
+    monkeypatch.chdir(tmp_path)
+
+    orch = Orchestrator(RunInputs(src=src, site=preset))
+    called = []
+
+    def rec(name):
+        def _inner(*args, **kwargs):
+            called.append(name)
+        return _inner
+
+    monkeypatch.setattr(orch, "parse", rec("parse"))
+    monkeypatch.setattr(orch, "integrate", rec("integrate"))
+    monkeypatch.setattr(orch, "map", rec("map"))
+    monkeypatch.setattr(orch, "fit", rec("fit"))
+    monkeypatch.setattr(orch, "translate", rec("translate"))
+    monkeypatch.setattr(orch, "report", rec("report"))
+
+    out = orch.run_all()
+    assert out.is_dir()
+    assert (out / "run_context.json").exists()
+    assert called == ["parse", "integrate", "map", "fit", "translate", "report"]


### PR DESCRIPTION
## Summary
- add lightweight Run Easy orchestrator sequencing parse→integrate→map→fit→translate→report
- extend `kielproc` CLI with `one-click` subcommand and default site preset
- cover orchestrator flow and new CLI entry with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b9db34c9ac83228eabcd24eb3b3ce3