### PR TITLE
feat: insert Run Easy tab into main window

### DIFF
--- a/app/gui/main_window.py
+++ b/app/gui/main_window.py
@@ -11,14 +11,27 @@ class MainWindow(QMainWindow):
         self.setCentralWidget(self.tabs)
 
         # existing tabs assembled elsewhere…
-        # Insert Run Easy as the first tab so all others shift one index to the right
-        try:
+        # Always prepend the Run Easy panel so operators see it first
+        self._insert_run_easy()
+
+    def _insert_run_easy(self) -> None:
+        """Insert the Run Easy panel as the first tab.
+
+        Any import or wiring issues are treated as non-fatal; the GUI should
+        continue to load even if the panel cannot be constructed (e.g. missing
+        optional dependencies).  In such cases the error is surfaced to the
+        console for easier diagnosis.
+        """
+
+        try:  # pragma: no cover - exercised via unit tests
             from .run_easy_panel import RunEasyPanel
+
             run_easy = RunEasyPanel(self)
             # Assume a QTabWidget attribute named `tabs`; adjust if your object differs
             self.tabs.insertTab(0, run_easy, "Run Easy")
             self.tabs.setCurrentIndex(0)
-        except Exception as e:
-            # Non‑fatal: if wiring fails (e.g., different widget name), surface in console and continue
+        except Exception as e:  # pragma: no cover - exercised via unit tests
+            # Non-fatal: if wiring fails (e.g., different widget name), surface in console and continue
             import sys
+
             print(f"[RunEasy] wiring failed: {e}", file=sys.stderr)

--- a/kielproc_monorepo/tests/test_run_easy_panel_integration.py
+++ b/kielproc_monorepo/tests/test_run_easy_panel_integration.py
@@ -1,0 +1,69 @@
+import types
+import sys
+import importlib
+from pathlib import Path
+
+# Ensure repository root (containing the 'app' package) is importable
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+
+def _stub_qt():
+    """Create minimal PySide6 stubs sufficient for MainWindow tests."""
+    QtWidgets = types.ModuleType("PySide6.QtWidgets")
+
+    class DummyQMainWindow:
+        def __init__(self, parent=None):
+            pass
+
+        def setCentralWidget(self, w):
+            self.central = w
+
+    class DummyTabWidget:
+        def __init__(self, parent=None):
+            self._tabs = []
+
+        def insertTab(self, index, widget, label):
+            self._tabs.insert(index, (widget, label))
+
+        def setCurrentIndex(self, index):
+            self.current = index
+
+        def widget(self, index):
+            return self._tabs[index][0]
+
+        def tabText(self, index):
+            return self._tabs[index][1]
+
+        def count(self):
+            return len(self._tabs)
+
+    QtWidgets.QMainWindow = DummyQMainWindow
+    QtWidgets.QTabWidget = DummyTabWidget
+
+    base = types.ModuleType("PySide6")
+    base.QtWidgets = QtWidgets
+
+    sys.modules.setdefault("PySide6", base)
+    sys.modules.setdefault("PySide6.QtWidgets", QtWidgets)
+
+
+def test_run_easy_tab_is_first(monkeypatch):
+    _stub_qt()
+
+    # Provide a lightweight stub for RunEasyPanel so import succeeds
+    run_easy_mod = types.ModuleType("app.gui.run_easy_panel")
+
+    class DummyPanel:
+        def __init__(self, parent=None):
+            pass
+
+    run_easy_mod.RunEasyPanel = DummyPanel
+    sys.modules["app.gui.run_easy_panel"] = run_easy_mod
+
+    mw_module = importlib.import_module("app.gui.main_window")
+    win = mw_module.MainWindow()
+
+    assert win.tabs.count() == 1
+    assert win.tabs.tabText(0) == "Run Easy"
+    assert isinstance(win.tabs.widget(0), DummyPanel)


### PR DESCRIPTION
## Summary
- always insert Run Easy panel as the first tab in the main window
- add regression test to ensure Run Easy tab is present and first

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ba7d8ec85c8322b7575ddcd70e067b