### PR TITLE
feat(gui): add legacy parser panel

### DIFF
--- a/app/gui/legacy_parser_panel.py
+++ b/app/gui/legacy_parser_panel.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import sys, os, json
+from pathlib import Path
+import tkinter as tk
+from tkinter import ttk, filedialog, messagebox
+from tkinter.scrolledtext import ScrolledText
+
+# Repo root: .../<repo_root> (contains 'app' and 'kielproc_monorepo')
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+# Legacy parser package root: .../kielproc_monorepo/tools/legacy_parser
+_LEGACY_PKG_ROOT = _REPO_ROOT / "kielproc_monorepo" / "tools" / "legacy_parser"
+if str(_LEGACY_PKG_ROOT) not in sys.path:
+    sys.path.insert(0, str(_LEGACY_PKG_ROOT))
+
+try:
+    # The package layout is tools/legacy_parser/legacy_parser/parser.py
+    from legacy_parser.parser import parse_legacy_workbook  # type: ignore
+except Exception as e:
+    parse_legacy_workbook = None  # type: ignore
+    _IMPORT_ERR = e
+else:
+    _IMPORT_ERR = None
+
+
+class LegacyParserPanel(ttk.Frame):
+    """
+    Notebook tab embedding the Legacy XLSX → CSV parser.
+    Mirrors tools/legacy_parser/parser_gui.py but as a Frame.
+    """
+
+    def __init__(self, master: tk.Misc | None = None) -> None:
+        super().__init__(master)
+
+        self.var_infile = tk.StringVar()
+        self.var_outdir = tk.StringVar()
+        self.var_folder = tk.StringVar()
+        self.var_thresh = tk.StringVar(value="1e-6")
+
+        self.columnconfigure(1, weight=1)
+        row = 0
+
+        ttk.Label(self, text="Legacy XLSX → CSV Parser", font=("", 12, "bold")).grid(row=row, column=0, columnspan=3, sticky="w", pady=(4, 8)); row += 1
+
+        ttk.Label(self, text="XLSX workbook").grid(row=row, column=0, sticky="w")
+        ttk.Entry(self, textvariable=self.var_infile).grid(row=row, column=1, sticky="ew")
+        ttk.Button(self, text="Browse…", command=self._pick_xlsx).grid(row=row, column=2, sticky="w"); row += 1
+
+        ttk.Label(self, text="Output base directory").grid(row=row, column=0, sticky="w", pady=(4, 0))
+        ttk.Entry(self, textvariable=self.var_outdir).grid(row=row, column=1, sticky="ew", pady=(4, 0))
+        ttk.Button(self, text="Choose…", command=self._pick_outdir).grid(row=row, column=2, sticky="w", pady=(4, 0)); row += 1
+
+        ttk.Label(self, text="Folder name (optional)").grid(row=row, column=0, sticky="w")
+        ttk.Entry(self, textvariable=self.var_folder).grid(row=row, column=1, sticky="ew"); row += 1
+
+        ttk.Label(self, text="Piccolo flat threshold").grid(row=row, column=0, sticky="w")
+        ttk.Entry(self, textvariable=self.var_thresh, width=10).grid(row=row, column=1, sticky="w"); row += 1
+
+        self.btn = ttk.Button(self, text="Parse", command=self._run_parse)
+        self.btn.grid(row=row, column=1, sticky="w", pady=6); row += 1
+
+        self.log = ScrolledText(self, height=12, state="disabled")
+        self.log.grid(row=row, column=0, columnspan=3, sticky="nsew", pady=(6, 0)); row += 1
+        self.rowconfigure(row-1, weight=1)
+
+        if _IMPORT_ERR is not None:
+            self._log(f"[import] legacy parser unavailable: {_IMPORT_ERR}")
+
+    # --- UI helpers ------------------------------------------------------
+    def _pick_xlsx(self):
+        p = filedialog.askopenfilename(title="Select legacy workbook", filetypes=[("Excel files", "*.xlsx *.xls *.xlsm")])
+        if p:
+            self.var_infile.set(p)
+
+    def _pick_outdir(self):
+        d = filedialog.askdirectory(title="Select output directory")
+        if d:
+            self.var_outdir.set(d)
+
+    def _log(self, msg: str):
+        self.log.configure(state="normal")
+        try:
+            self.log.insert("end", msg + "\n")
+            self.log.see("end")
+        finally:
+            self.log.configure(state="disabled")
+
+    # --- Action ----------------------------------------------------------
+    def _run_parse(self):
+        if parse_legacy_workbook is None:
+            messagebox.showerror("Unavailable", f"Legacy parser import failed: {_IMPORT_ERR}")
+            return
+
+        infile = Path(self.var_infile.get())
+        if not infile.exists():
+            messagebox.showerror("Missing file", f"Workbook not found: {infile}")
+            return
+
+        try:
+            thresh = float(self.var_thresh.get() or "0.0")
+        except ValueError:
+            messagebox.showerror("Invalid threshold", f"Not a number: {self.var_thresh.get()}")
+            return
+
+        base_out = Path(self.var_outdir.get()) if self.var_outdir.get() else infile.parent
+        folder_name = (self.var_folder.get().strip() or f"{infile.stem}_parsed").replace(os.sep, "_")
+        outd = base_out / folder_name
+        outd.mkdir(parents=True, exist_ok=True)
+
+        self._log(f"[parse] {infile.name} → {outd}")
+        try:
+            frames, summary = parse_legacy_workbook(infile, return_mode="frames", piccolo_flat_threshold=thresh)
+            # Write CSVs and summary JSON
+            for i, (port_key, df) in enumerate(frames.items(), start=1):
+                csv_path = outd / f"PORT {i}.csv"
+                df.to_csv(csv_path, index=False)
+                try:
+                    summary.setdefault("sheets", [])
+                    if i-1 < len(summary["sheets"]):
+                        summary["sheets"][i-1]["csv_path"] = str(csv_path)
+                except Exception:
+                    pass
+            (outd / f"{infile.stem}__parse_summary.json").write_text(json.dumps(summary or {}, indent=2))
+        except Exception as e:
+            self._log(f"[error] {e}")
+            messagebox.showerror("Parse failed", str(e))
+            return
+
+        self._log("✅ Done.")
+        messagebox.showinfo("Parse complete", f"Outputs in: {outd}")

--- a/kielproc_monorepo/gui/app_gui.py
+++ b/kielproc_monorepo/gui/app_gui.py
@@ -66,6 +66,13 @@ except Exception as _e:  # non-fatal
     print(f"[RunEasy] import failed: {_e}", file=sys.stderr)
     RunEasyPanel = None
 
+try:
+    # Optional tab: legacy XLSX→CSV parser as a Notebook panel
+    from app.gui.legacy_parser_panel import LegacyParserPanel  # noqa: E402
+except Exception as _e:  # non-fatal
+    print(f"[LegacyParser] import failed: {_e}", file=sys.stderr)
+    LegacyParserPanel = None
+
 def _float_or_zero(value: str, default: float = 0.0) -> float:
     """Convert *value* to float, returning *default* when empty.
 
@@ -140,6 +147,14 @@ class App(tk.Tk):
                 self.nb.select(run_easy)
             except Exception as _e:
                 print(f"[RunEasy] wiring failed: {_e}", file=sys.stderr)
+
+        # Append "Legacy Parser" tab if available
+        if "LegacyParserPanel" in globals() and LegacyParserPanel is not None:
+            try:
+                legacy_tab = LegacyParserPanel(self.nb)
+                self.nb.add(legacy_tab, text="Legacy Parser")
+            except Exception as _e:
+                print(f"[LegacyParser] wiring failed: {_e}", file=sys.stderr)
 
     def _build(self):
         self.nb = ttk.Notebook(self)

--- a/kielproc_monorepo/tests/test_run_easy_panel_integration.py
+++ b/kielproc_monorepo/tests/test_run_easy_panel_integration.py
@@ -9,20 +9,43 @@ sys.path.insert(0, str(ROOT))
 
 
 def _stub_tk():
-    """Create minimal tkinter stubs sufficient for MainWindow tests."""
+    """Create expansive tkinter stubs sufficient for app_gui imports."""
     tk = types.ModuleType("tkinter")
     ttk = types.ModuleType("tkinter.ttk")
 
-    class DummyTk:
-        def __init__(self, parent=None):
+    class DummyWidget:
+        def __init__(self, *args, **kwargs):
             pass
 
-    class DummyNotebook:
+        def __getattr__(self, name):
+            def method(*args, **kwargs):
+                return None
+
+            return method
+
+    class DummyVar:
+        def __init__(self, value=None):
+            self._value = value
+
+        def get(self):
+            return self._value
+
+        def set(self, v):
+            self._value = v
+
+        def trace_add(self, *args, **kwargs):
+            pass
+
+    class DummyNotebook(DummyWidget):
         def __init__(self, parent=None):
+            super().__init__()
             self._tabs = []
 
         def insert(self, index, widget, text=""):
             self._tabs.insert(index, (widget, text))
+
+        def add(self, widget, text=""):
+            self._tabs.append((widget, text))
 
         def select(self, widget):
             self.current = widget
@@ -35,14 +58,46 @@ def _stub_tk():
                 if w is widget and option == "text":
                     return label
 
-        def pack(self, **kwargs):
+    # Basic widgets and variables
+    tk.Tk = DummyWidget
+    tk.Canvas = DummyWidget
+    tk.Widget = DummyWidget
+    tk.StringVar = tk.BooleanVar = tk.DoubleVar = tk.IntVar = DummyVar
+    ttk.Notebook = DummyNotebook
+    ttk.Frame = ttk.Label = ttk.Entry = ttk.Button = ttk.Checkbutton = ttk.Scrollbar = ttk.Separator = ttk.LabelFrame = ttk.Combobox = ttk.Treeview = DummyWidget
+    ttk.Style = DummyWidget
+
+    # Submodules expected during import
+    filedialog = types.ModuleType("tkinter.filedialog")
+    filedialog.askopenfilename = lambda *a, **k: ""
+    filedialog.askdirectory = lambda *a, **k: ""
+    messagebox = types.ModuleType("tkinter.messagebox")
+    messagebox.showerror = lambda *a, **k: None
+    messagebox.showinfo = lambda *a, **k: None
+    scrolledtext = types.ModuleType("tkinter.scrolledtext")
+    scrolledtext.ScrolledText = DummyWidget
+
+    class DummyFont(DummyWidget):
+        def cget(self, key):
+            return 10
+
+        def configure(self, **kwargs):
             pass
 
-    tk.Tk = DummyTk
-    ttk.Notebook = DummyNotebook
+    font = types.ModuleType("tkinter.font")
+    font.Font = DummyFont
+    font.nametofont = lambda *a, **k: DummyFont()
+
+    simpledialog = types.ModuleType("tkinter.simpledialog")
+    simpledialog.SimpleDialog = DummyWidget
 
     sys.modules["tkinter"] = tk
     sys.modules["tkinter.ttk"] = ttk
+    sys.modules["tkinter.filedialog"] = filedialog
+    sys.modules["tkinter.messagebox"] = messagebox
+    sys.modules["tkinter.scrolledtext"] = scrolledtext
+    sys.modules["tkinter.font"] = font
+    sys.modules["tkinter.simpledialog"] = simpledialog
 
 
 def test_run_easy_tab_is_first(monkeypatch):
@@ -58,10 +113,17 @@ def test_run_easy_tab_is_first(monkeypatch):
     run_easy_mod.RunEasyPanel = DummyPanel
     sys.modules["app.gui.run_easy_panel"] = run_easy_mod
 
+    # Ensure modules depending on tkinter are re-imported after stubbing
+    sys.modules.pop("ui_polish", None)
+    sys.modules.pop("kielproc_monorepo.gui.app_gui", None)
+
     mw_module = importlib.import_module("app.gui.main_window")
     win = mw_module.MainWindow()
 
-    assert len(win.tabs.tabs()) == 1
-    tab_widget = win.tabs.tabs()[0]
-    assert win.tabs.tab(tab_widget, "text") == "Run Easy"
+    notebook = win.__dict__.get("tabs") or win.__dict__.get("nb")
+    assert notebook is not None
+    tabs = notebook.tabs()
+    assert tabs
+    tab_widget = tabs[0]
+    assert notebook.tab(tab_widget, "text") == "Run Easy"
     assert isinstance(tab_widget, DummyPanel)


### PR DESCRIPTION
## Summary
- add LegacyParserPanel embedding legacy XLSX→CSV parser
- expose Legacy Parser tab in main GUI when available
- delegate legacy `MainWindow` to unified app with test-friendly fallback
- expand integration test with extensive tkinter stubs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68baab332b948322aba2ed0113bd6281