### PR TITLE
feat: add output directory option

### DIFF
--- a/kielproc_monorepo/kielproc/cli.py
+++ b/kielproc_monorepo/kielproc/cli.py
@@ -32,6 +32,7 @@ def build_parser():
     oc.add_argument("--site", default="DefaultSite", choices=PRESETS.keys())
     oc.add_argument("--baro", type=float, default=None, help="Override barometric pressure in Pa")
     oc.add_argument("--stamp", type=str, default=None, help="Override run stamp YYYYMMDD_HHMM (NZT)")
+    oc.add_argument("--out", type=Path, default=None, help="Output base directory (RUN_* will be created here)")
 
     i0 = sub.add_parser("results", help="Compute legacy-style results from a logger CSV")
     i0.add_argument("--csv", required=True, help="Input logger CSV path")
@@ -108,7 +109,7 @@ def main(argv=None):
     ap = build_parser()
     a = ap.parse_args(argv)
     if a.cmd == "one-click":
-        out = run_easy_legacy(Path(a.src), PRESETS[a.site], baro_override_Pa=a.baro, run_stamp=a.stamp)
+        out = run_easy_legacy(Path(a.src), PRESETS[a.site], baro_override_Pa=a.baro, run_stamp=a.stamp, output_base=a.out)
         print(json.dumps({"ok": True, "out_dir": str(out)}))
     elif a.cmd == "results":
         cfg_dict = {}

--- a/kielproc_monorepo/kielproc/run_easy.py
+++ b/kielproc_monorepo/kielproc/run_easy.py
@@ -37,6 +37,7 @@ class RunInputs:
     site: SitePreset
     baro_override_Pa: Optional[float] = None
     run_stamp: Optional[str] = None  # YYYYMMDD_HHMM in NZT
+    output_base: Optional[Path] = None  # If set, RUN_* will be created here
 
 
 class OneClickError(Exception):
@@ -302,7 +303,8 @@ class Orchestrator:
         self._progress("Preflight…")
         self.preflight()
         stamp = self._stamp()
-        out = Path(f"RUN_{stamp}")
+        base = (self.run.output_base or Path.cwd())
+        out = base / f"RUN_{stamp}"
         dirs = self._mkdirs(out)
         # persist run context for audit
         context_path = out / "run_context.json"
@@ -365,9 +367,11 @@ def run_easy_legacy(
     site: SitePreset,
     baro_override_Pa: Optional[float] = None,
     run_stamp: Optional[str] = None,
+    *,
+    output_base: Optional[Path] = None,
     progress_cb: Optional[Callable[[str], None]] = None,
 ) -> Path:
     """Run the full pipeline for a legacy workbook using ``SitePreset`` defaults."""
 
-    run = RunInputs(src=src, site=site, baro_override_Pa=baro_override_Pa, run_stamp=run_stamp)
+    run = RunInputs(src=src, site=site, baro_override_Pa=baro_override_Pa, run_stamp=run_stamp, output_base=output_base)
     return Orchestrator(run, progress_cb=progress_cb).run_all()

--- a/kielproc_monorepo/tests/test_cli_one_click.py
+++ b/kielproc_monorepo/tests/test_cli_one_click.py
@@ -7,8 +7,9 @@ from kielproc import cli
 def test_cli_one_click(monkeypatch, tmp_path, capsys):
     out_dir = tmp_path / "out"
 
-    def fake_run(src, site, baro_override_Pa=None, run_stamp=None):
+    def fake_run(src, site, baro_override_Pa=None, run_stamp=None, *, output_base=None):
         assert src == Path(tmp_path / "book.xlsx")
+        assert output_base is None
         return out_dir
 
     monkeypatch.setattr(cli, "run_easy_legacy", fake_run)

--- a/kielproc_monorepo/tests/test_run_easy_orchestrator.py
+++ b/kielproc_monorepo/tests/test_run_easy_orchestrator.py
@@ -28,3 +28,29 @@ def test_run_all_sequences_steps(tmp_path, monkeypatch):
     assert out.is_dir()
     assert (out / "run_context.json").exists()
     assert called == ["parse", "integrate", "map", "fit", "translate", "report"]
+
+
+def test_run_all_uses_output_base(tmp_path, monkeypatch):
+    preset = SitePreset(name="T", geometry={}, instruments={}, defaults={})
+    src = tmp_path / "book.xlsx"
+    src.write_text("dummy")
+    other = tmp_path / "elsewhere"
+    other.mkdir()
+    monkeypatch.chdir(other)
+
+    run = RunInputs(src=src, site=preset, output_base=tmp_path)
+    orch = Orchestrator(run)
+
+    def noop(*args, **kwargs):
+        pass
+
+    monkeypatch.setattr(orch, "parse", noop)
+    monkeypatch.setattr(orch, "integrate", noop)
+    monkeypatch.setattr(orch, "map", noop)
+    monkeypatch.setattr(orch, "fit", noop)
+    monkeypatch.setattr(orch, "translate", noop)
+    monkeypatch.setattr(orch, "report", noop)
+
+    out = orch.run_all()
+    assert out.is_dir()
+    assert out.parent == tmp_path


### PR DESCRIPTION
## Summary
- allow specifying output base directory for one-click runs
- expose new `--out` CLI option
- test explicit output directory handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68babceeb7088322801153821dd437ee