### PR TITLE
Expose run summary and artifacts from run_easy_legacy

### DIFF
--- a/kielproc_monorepo/kielproc/cli.py
+++ b/kielproc_monorepo/kielproc/cli.py
@@ -109,8 +109,23 @@ def main(argv=None):
     ap = build_parser()
     a = ap.parse_args(argv)
     if a.cmd == "one-click":
-        out = run_easy_legacy(Path(a.src), PRESETS[a.site], baro_override_Pa=a.baro, run_stamp=a.stamp, output_base=a.out)
-        print(json.dumps({"ok": True, "out_dir": str(out)}))
+        out, summary, artifacts = run_easy_legacy(
+            Path(a.src),
+            PRESETS[a.site],
+            baro_override_Pa=a.baro,
+            run_stamp=a.stamp,
+            output_base=a.out,
+        )
+        print(
+            json.dumps(
+                {
+                    "ok": True,
+                    "out_dir": str(out),
+                    "summary": summary,
+                    "artifacts": artifacts,
+                }
+            )
+        )
     elif a.cmd == "results":
         cfg_dict = {}
         if a.config:

--- a/kielproc_monorepo/kielproc/run_easy.py
+++ b/kielproc_monorepo/kielproc/run_easy.py
@@ -416,8 +416,25 @@ def run_easy_legacy(
     *,
     output_base: Optional[Path] = None,
     progress_cb: Optional[Callable[[str], None]] = None,
-) -> Path:
-    """Run the full pipeline for a legacy workbook using ``SitePreset`` defaults."""
+) -> tuple[Path, Dict, List[str]]:
+    """Run the full pipeline for a legacy workbook using ``SitePreset`` defaults.
 
-    run = RunInputs(src=src, site=site, baro_override_Pa=baro_override_Pa, run_stamp=run_stamp, output_base=output_base)
-    return Orchestrator(run, progress_cb=progress_cb).run_all()
+    Returns
+    -------
+    tuple
+        ``(run_dir, summary, artifacts)`` where ``run_dir`` is the output
+        directory path, ``summary`` contains warning/error details, and
+        ``artifacts`` is a list of generated tables/plots.
+    """
+
+    run = RunInputs(
+        src=src,
+        site=site,
+        baro_override_Pa=baro_override_Pa,
+        run_stamp=run_stamp,
+        output_base=output_base,
+    )
+    orch = Orchestrator(run, progress_cb=progress_cb)
+    out = orch.run_all()
+    # return triple so app GUI can display warnings/plots/tables
+    return out, orch.summary, [str(p) for p in orch.artifacts]

--- a/kielproc_monorepo/tests/test_cli_one_click.py
+++ b/kielproc_monorepo/tests/test_cli_one_click.py
@@ -10,7 +10,7 @@ def test_cli_one_click(monkeypatch, tmp_path, capsys):
     def fake_run(src, site, baro_override_Pa=None, run_stamp=None, *, output_base=None):
         assert src == Path(tmp_path / "book.xlsx")
         assert output_base is None
-        return out_dir
+        return out_dir, {"warnings": ["w"], "errors": []}, [str(out_dir / "a.csv")]
 
     monkeypatch.setattr(cli, "run_easy_legacy", fake_run)
     args = ["one-click", str(tmp_path / "book.xlsx"), "--site", "DefaultSite"]
@@ -19,3 +19,5 @@ def test_cli_one_click(monkeypatch, tmp_path, capsys):
     data = json.loads(captured)
     assert data["ok"] is True
     assert data["out_dir"] == str(out_dir)
+    assert data["summary"]["warnings"] == ["w"]
+    assert data["artifacts"] == [str(out_dir / "a.csv")]

--- a/kielproc_monorepo/tests/test_run_easy_panel_runner.py
+++ b/kielproc_monorepo/tests/test_run_easy_panel_runner.py
@@ -12,7 +12,7 @@ def test_runner_respects_output_base(tmp_path, monkeypatch):
         calls["output_base"] = output_base
         if progress_cb:
             progress_cb("step")
-        return Path("RUN_fake")
+        return Path("RUN_fake"), {"warnings": [], "errors": []}, [Path("tab.csv")]
 
     monkeypatch.setattr(rep, "run_easy_legacy", fake_run_easy_legacy)
 


### PR DESCRIPTION
## Summary
- Extend `run_easy_legacy` to return run directory, summary details, and produced artifacts so UIs can surface warnings and outputs
- Update CLI to propagate summary and artifact information
- Adjust tests for new API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68bb6c51de808322ae729a1ec0e55982