### PR TITLE
Refactor geometry to area-based API

### DIFF
--- a/kielproc_monorepo/gui/app_gui.py
+++ b/kielproc_monorepo/gui/app_gui.py
@@ -54,9 +54,8 @@ from kielproc.legacy_results import compute_results as compute_results_cli
 from kielproc.qa import DEFAULT_W_MAX, DEFAULT_DELTA_OPP_MAX
 from kielproc.geometry import (
     Geometry,
-    plane_area,
+    duct_area,
     throat_area,
-    effective_upstream_area,
     r_ratio,
     beta_from_geometry,
 )
@@ -945,14 +944,12 @@ class App(tk.Tk):
         g = Geometry(
             duct_height_m=float(self.var_height.get()),
             duct_width_m=float(self.var_width.get()),
-            upstream_area_m2=A1,
-            throat_diameter_m=dt if dt else None,
+            duct_area_m2=A1,
             throat_area_m2=at if at and (dt is None) else None,
-            rho_default_kg_m3=float(self.var_rho.get()),
         )
-        As = plane_area(g)
+        As = duct_area(g)
         At = throat_area(g)
-        A1_eff = effective_upstream_area(g)
+        A1_eff = duct_area(g)
         warn = []
         if At >= As:
             warn.append("At >= As")

--- a/kielproc_monorepo/kielproc/__init__.py
+++ b/kielproc_monorepo/kielproc/__init__.py
@@ -18,12 +18,10 @@ from .qa import qa_indices
 from .aggregate import RunConfig, integrate_run
 from .geometry import (
     Geometry,
-    plane_area,
-    effective_upstream_area,
+    duct_area,
     throat_area,
     r_ratio,
     beta_from_geometry,
-    geometry_summary,
 )
 from .legacy_results import ResultsConfig, compute_results as compute_legacy_results
 
@@ -37,7 +35,7 @@ __all__ = [
     "load_legacy_excel", "load_logger_csv", "unify_schema",
     "compute_translation_table", "apply_translation",
     "write_summary_tables", "plot_alignment", "qa_indices",
-    "Geometry", "plane_area", "effective_upstream_area", "throat_area", "r_ratio", "beta_from_geometry", "geometry_summary",
+    "Geometry", "duct_area", "throat_area", "r_ratio", "beta_from_geometry",
     "RunConfig", "integrate_run",
     "ResultsConfig", "compute_legacy_results",
 ]

--- a/kielproc_monorepo/kielproc_gui_adapter.py
+++ b/kielproc_monorepo/kielproc_gui_adapter.py
@@ -15,9 +15,8 @@ from kielproc.report import write_summary_tables, plot_alignment
 from kielproc.qa import qa_indices, DEFAULT_DELTA_OPP_MAX, DEFAULT_W_MAX
 from kielproc.geometry import (
     Geometry,
-    plane_area,
+    duct_area,
     throat_area,
-    effective_upstream_area,
     r_ratio,
     beta_from_geometry,
 )
@@ -64,19 +63,17 @@ def map_verification_plane(csv_or_df: Union[Path, pd.DataFrame], qs_col: str,
         out["Time_s"] = out["Sample"] / float(sampling_hz)
 
     # Persist geometry fields
-    As = plane_area(geom)
+    As = duct_area(geom)
     At = throat_area(geom)
-    A1 = effective_upstream_area(geom)
+    A1 = As
     out["duct_height_m"] = geom.duct_height_m
     out["duct_width_m"] = geom.duct_width_m
     out["As_m2"] = As
-    out["upstream_area_m2"] = geom.upstream_area_m2
     out["A1_m2"] = A1
     out["At_m2"] = At
     out["r"] = r
     out["beta"] = beta
-    out["rho_default_kg_m3"] = geom.rho_default_kg_m3
-    out["A1_auto_from_As"] = geom.upstream_area_m2 is None
+    out["A1_auto_from_As"] = geom.duct_area_m2 is None
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out.to_csv(out_path, index=False)

--- a/kielproc_monorepo/tests/test_gui_adapter_df.py
+++ b/kielproc_monorepo/tests/test_gui_adapter_df.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from pathlib import Path
+import math
 from kielproc.geometry import Geometry
 from kielproc_gui_adapter import (
     map_from_tot_and_static,
@@ -17,7 +18,13 @@ def test_map_from_tot_and_static_with_dataframe(tmp_path: Path):
         "p_t": [10.0, 11.0],
         "p_s": [1.0, 1.2],
     })
-    geom = Geometry(duct_height_m=1.0, duct_width_m=1.0, throat_diameter_m=0.1)
+    geom = Geometry(
+        duct_height_m=1.0,
+        duct_width_m=1.0,
+        throat_area_m2=math.pi * (0.1 ** 2) / 4.0,
+        static_port_area_m2=2.0,
+        total_port_area_m2=1.0,
+    )
     out = tmp_path / "mapped.csv"
     res_path = map_from_tot_and_static(df, "p_t", "p_s", geom, None, out)
     out_df = pd.read_csv(res_path)
@@ -61,7 +68,13 @@ def test_compute_setpoints_from_dataframe(tmp_path: Path):
 
 def test_process_legacy_parsed_csv(tmp_path: Path):
     df = pd.DataFrame({"VP": [1.0, 2.0, 3.0]})
-    geom = Geometry(duct_height_m=1.0, duct_width_m=1.0, throat_diameter_m=0.1)
+    geom = Geometry(
+        duct_height_m=1.0,
+        duct_width_m=1.0,
+        throat_area_m2=math.pi * (0.1 ** 2) / 4.0,
+        static_port_area_m2=2.0,
+        total_port_area_m2=1.0,
+    )
     out = tmp_path / "legacy_qs_qp_dpvent.csv"
     wrote, res_df = process_legacy_parsed_csv(df, geom, None, out)
     assert wrote == out

--- a/kielproc_monorepo/tests/test_run_easy_orchestrator.py
+++ b/kielproc_monorepo/tests/test_run_easy_orchestrator.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pandas as pd
+import math
 
 from kielproc.run_easy import Orchestrator, RunInputs, SitePreset
 
@@ -62,7 +63,9 @@ def test_map_ignores_unknown_geometry_keys(tmp_path):
     geom = {
         "duct_height_m": 1.0,
         "duct_width_m": 1.0,
-        "throat_diameter_m": 0.1,
+        "throat_area_m2": math.pi * (0.1 ** 2) / 4.0,
+        "static_port_area_m2": 2.0,
+        "total_port_area_m2": 1.0,
         # Extra field not recognized by Geometry dataclass
         "duct_diameter_m": 2.5,
     }


### PR DESCRIPTION
## Summary
- replace diameter-based geometry with area-driven dataclass
- compute beta from duct/throat areas and r from port areas
- adjust adapter, GUI and tests for new geometry API

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68bb6d8c74048322acbb0adbef145b83