### PR TITLE
Handle missing geometry and skip non-port CSVs in mapping

### DIFF
--- a/kielproc_monorepo/tests/test_run_easy_orchestrator.py
+++ b/kielproc_monorepo/tests/test_run_easy_orchestrator.py
@@ -77,7 +77,7 @@ def test_map_ignores_unknown_geometry_keys(tmp_path):
     ports_dir = base_dir / "ports_csv"
     ports_dir.mkdir(parents=True)
 
-    df = pd.DataFrame({"VP": [1.0, 2.0]})
+    df = pd.DataFrame({"VP": [1.0, 2.0], "Temperature": [20.0, 21.0]})
     csv = ports_dir / "p1.csv"
     df.to_csv(csv, index=False)
 


### PR DESCRIPTION
## Summary
- require geometry and port area ratio before mapping
- skip CSVs that don't correspond to recognised port files
- use legacy parser metadata to discover ports and ignore stray sheets

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68bb9908b8f88322867d22c16aa658dc