### PR TITLE
Allow translation beta override in Run Easy UI

### DIFF
--- a/kielproc_monorepo/kielproc/run_easy.py
+++ b/kielproc_monorepo/kielproc/run_easy.py
@@ -141,11 +141,14 @@ class Orchestrator:
         except Exception:
             geom = None
 
-        area_ratio = beta = None
+        area_ratio = geom_dict.get("r") or geom_dict.get("area_ratio")
+        beta = geom_dict.get("beta")
         if geom is not None:
             try:
-                area_ratio = r_ratio(geom)
-                beta = beta_from_geometry(geom)
+                if area_ratio is None:
+                    area_ratio = r_ratio(geom)
+                if beta is None:
+                    beta = beta_from_geometry(geom)
             except Exception:
                 pass
 
@@ -300,6 +303,7 @@ class Orchestrator:
         block_specs = {Path(p).stem: p for p in mapped}
         outdir = base_dir / "_fit"
         outdir.mkdir(parents=True, exist_ok=True)
+        beta_override = self.run.site.defaults.get("beta_translate")
         try:
             res = fit_alpha_beta(
                 block_specs,
@@ -308,6 +312,7 @@ class Orchestrator:
                 lambda_ratio=1.0,
                 max_lag=300,
                 outdir=outdir,
+                beta_override=beta_override,
             )
             for k in ("per_block_csv", "per_block_json", "pooled_csv", "pooled_json", "align_png"):
                 v = res.get(k)

--- a/kielproc_monorepo/kielproc/translate.py
+++ b/kielproc_monorepo/kielproc/translate.py
@@ -18,6 +18,7 @@ def compute_translation_table(
     bootstrap: bool = False,
     n_boot: int = 200,
     random_state: int | None = None,
+    beta_override: float | None = None,
 ):
     rows = []
     for name, df in blocks.items():
@@ -30,28 +31,64 @@ def compute_translation_table(
         # Positive ``lag`` means piccolo lags the reference.  Align by shifting
         # piccolo forward (left) with ``shift_series(y, -lag)``.
         y_shift = shift_series(y, -lag)
-        m, b, sa, sb = deming_fit(
-            x,
-            y_shift,
-            lambda_ratio=lambda_ratio,
-            bootstrap=bootstrap,
-            n_boot=n_boot,
-            random_state=random_state,
+        if beta_override is not None:
+            y_adj = y_shift - beta_override
+            m, _, sa, _ = deming_fit(
+                x,
+                y_adj,
+                lambda_ratio=lambda_ratio,
+                bootstrap=bootstrap,
+                n_boot=n_boot,
+                random_state=random_state,
+            )
+            b = float(beta_override)
+            sb = float("nan")
+        else:
+            m, b, sa, sb = deming_fit(
+                x,
+                y_shift,
+                lambda_ratio=lambda_ratio,
+                bootstrap=bootstrap,
+                n_boot=n_boot,
+                random_state=random_state,
+            )
+        rows.append(
+            dict(
+                block=name,
+                alpha=m,
+                beta=b,
+                alpha_se=sa,
+                beta_se=sb,
+                lag_samples=int(lag),
+                r_peak=float(r_peak),
+            )
         )
-        rows.append(dict(block=name, alpha=m, beta=b, alpha_se=sa, beta_se=sb,
-                         lag_samples=int(lag), r_peak=float(r_peak)))
     tidy = pd.DataFrame(rows).set_index("block") if rows else pd.DataFrame(columns=["alpha","beta","alpha_se","beta_se","lag_samples"])
     pooled = None
-    if not tidy.empty and tidy["alpha_se"].gt(0).all() and tidy["beta_se"].gt(0).all():
+    if (
+        beta_override is None
+        and not tidy.empty
+        and tidy["alpha_se"].gt(0).all()
+        and tidy["beta_se"].gt(0).all()
+    ):
         Va = tidy["alpha_se"]**2
         Vb = tidy["beta_se"]**2
         cov_ab = np.zeros_like(Va)
         a_hat, a_se, tau2_a, b_hat, b_se, tau2_b, Q_a, Q_b, cov_pooled = \
             pool_alpha_beta_random_effects(tidy["alpha"], Va, tidy["beta"], Vb, cov_ab)
-        pooled = dict(alpha=a_hat, alpha_se=a_se, tau2_alpha=tau2_a,
-                      beta=b_hat,  beta_se=b_se,  tau2_beta=tau2_b,
-                      cov_ab=cov_pooled[0, 1],
-                      Q_alpha=Q_a[0], k_alpha=Q_a[1], Q_beta=Q_b[0], k_beta=Q_b[1])
+        pooled = dict(
+            alpha=a_hat,
+            alpha_se=a_se,
+            tau2_alpha=tau2_a,
+            beta=b_hat,
+            beta_se=b_se,
+            tau2_beta=tau2_b,
+            cov_ab=cov_pooled[0, 1],
+            Q_alpha=Q_a[0],
+            k_alpha=Q_a[1],
+            Q_beta=Q_b[0],
+            k_beta=Q_b[1],
+        )
     return tidy.reset_index(), pooled
 
 def apply_translation(

--- a/kielproc_monorepo/kielproc_gui_adapter.py
+++ b/kielproc_monorepo/kielproc_gui_adapter.py
@@ -94,6 +94,7 @@ def fit_alpha_beta(
     q_mean_col: str = "q_mean",
     qa_gate_opp: float | None = DEFAULT_DELTA_OPP_MAX,
     qa_gate_w: float | None = DEFAULT_W_MAX,
+    beta_override: float | None = None,
 ) -> Dict[str, object]:
     blocks = {name: _df_from(path) for name, path in block_specs.items()}
     per_block, pooled = compute_translation_table(
@@ -102,6 +103,7 @@ def fit_alpha_beta(
         picc_key=piccolo_col,
         lambda_ratio=lambda_ratio,
         max_lag=max_lag,
+        beta_override=beta_override,
     )
 
     # QA indices similar to CLI
@@ -172,6 +174,7 @@ def fit_alpha_beta_from_block_csv(
     q_mean_col: str = "q_mean",
     qa_gate_opp: float | None = DEFAULT_DELTA_OPP_MAX,
     qa_gate_w: float | None = DEFAULT_W_MAX,
+    beta_override: float | None = None,
 ) -> Dict[str, object]:
     """Fit α,β from a piccolo CSV, locating reference data automatically.
 
@@ -233,6 +236,7 @@ def fit_alpha_beta_from_block_csv(
         q_mean_col=q_mean_col,
         qa_gate_opp=qa_gate_opp,
         qa_gate_w=qa_gate_w,
+        beta_override=beta_override,
     )
 
 def translate_piccolo(csv_or_df: Union[Path, pd.DataFrame], alpha: float, beta: float,

--- a/kielproc_monorepo/tests/test_run_easy_panel_beta_override.py
+++ b/kielproc_monorepo/tests/test_run_easy_panel_beta_override.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+from test_run_easy_panel_integration import _stub_tk
+import sys
+
+
+def test_run_easy_panel_beta_override(tmp_path, monkeypatch):
+    _stub_tk()
+    sys.modules.pop("app.gui.run_easy_panel", None)
+    import app.gui.run_easy_panel as rep
+
+    wb = tmp_path / "src.xlsx"
+    wb.write_text("dummy")
+
+    panel = rep.RunEasyPanel()
+    panel.path_var.set(str(wb))
+    panel.outdir_var.set("")
+    panel.stamp_var.set("")
+    panel.static_port_area_var.set("1.0")
+    panel.total_port_area_var.set("2.0")
+    panel.beta_var.set("0.7")
+    panel.baro_var.set("")
+    panel.height_var.set("")
+    panel.width_var.set("")
+    panel.throat_var.set("")
+    panel.duct_diam_var.set("")
+    panel.throat_width_var.set("")
+    panel.throat_height_var.set("")
+
+    captured = {}
+
+    def fake_run_easy_legacy(src, preset, baro, stamp, **kwargs):
+        captured["beta"] = preset.geometry.get("beta")
+        return Path("RUN_fake"), {"warnings": [], "errors": []}, []
+
+    monkeypatch.setattr(rep, "run_easy_legacy", fake_run_easy_legacy)
+
+    panel._process()
+    panel._runner.join()
+
+    assert captured["beta"] == 0.7

--- a/kielproc_monorepo/tests/test_run_easy_panel_fit_beta_override.py
+++ b/kielproc_monorepo/tests/test_run_easy_panel_fit_beta_override.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+from test_run_easy_panel_integration import _stub_tk
+import sys
+
+
+def test_run_easy_panel_fit_beta_override(tmp_path, monkeypatch):
+    _stub_tk()
+    sys.modules.pop("app.gui.run_easy_panel", None)
+    import app.gui.run_easy_panel as rep
+
+    wb = tmp_path / "src.xlsx"
+    wb.write_text("dummy")
+
+    panel = rep.RunEasyPanel()
+    panel.path_var.set(str(wb))
+    panel.outdir_var.set("")
+    panel.stamp_var.set("")
+    panel.static_port_area_var.set("1.0")
+    panel.total_port_area_var.set("2.0")
+    panel.height_var.set("1.0")
+    panel.width_var.set("1.0")
+    panel.throat_width_var.set("1.0")
+    panel.throat_height_var.set("1.0")
+    panel.beta_fit_var.set("5.5")
+    panel.baro_var.set("")
+
+    captured = {}
+
+    def fake_run_easy_legacy(src, preset, baro, stamp, **kwargs):
+        captured["beta_translate"] = preset.defaults.get("beta_translate")
+        return Path("RUN_fake"), {"warnings": [], "errors": []}, []
+
+    monkeypatch.setattr(rep, "run_easy_legacy", fake_run_easy_legacy)
+
+    panel._process()
+    panel._runner.join()
+
+    assert captured["beta_translate"] == 5.5

--- a/kielproc_monorepo/tests/test_translate_beta_override.py
+++ b/kielproc_monorepo/tests/test_translate_beta_override.py
@@ -1,0 +1,14 @@
+import pandas as pd
+import numpy as np
+from kielproc.translate import compute_translation_table
+
+
+def test_compute_translation_table_beta_override():
+    x = np.array([0.0, 1.0, 2.0, 3.0])
+    y = 2.0 * x + 5.0
+    df = pd.DataFrame({"mapped_ref": x, "piccolo": y})
+    per, pooled = compute_translation_table({"b": df}, beta_override=5.0, max_lag=0)
+    row = per.iloc[0]
+    assert np.isclose(row["alpha"], 2.0)
+    assert np.isclose(row["beta"], 5.0)
+    assert pooled is None


### PR DESCRIPTION
## Summary
- add optional translation beta input to Run Easy
- plumb translation beta override through fit and translation utilities
- cover translation beta overrides with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68bbf421137c83228e9fd3249674b044