### PR TITLE
Expose discover_pairs and update run_easy imports

### DIFF
--- a/kielproc_monorepo/kielproc/aggregate.py
+++ b/kielproc_monorepo/kielproc/aggregate.py
@@ -108,6 +108,19 @@ def _discover_pairs(run_dir: Path, file_glob: str) -> tuple[list[tuple[str, Path
     pairs.sort(key=lambda kv: int(kv[0][1:]))
     return pairs, skipped
 
+
+def discover_pairs(run_dir: Path, file_glob: str) -> tuple[list[tuple[str, Path]], list[tuple[str, str]]]:
+    """Public wrapper exposing :func:`_discover_pairs`.
+
+    Parameters
+    ----------
+    run_dir:
+        Directory containing port CSV files.
+    file_glob:
+        Glob pattern used to discover candidate CSV files.
+    """
+    return _discover_pairs(run_dir, file_glob)
+
 R = 287.05  # J/(kg·K)
 
 # ——— Normalizer utilities ———

--- a/kielproc_monorepo/kielproc/run_easy.py
+++ b/kielproc_monorepo/kielproc/run_easy.py
@@ -16,6 +16,8 @@ from typing import Optional, Dict, List, Callable
 import json
 import time
 
+from .aggregate import integrate_run, RunConfig, discover_pairs
+
 NZT = "Pacific/Auckland"
 
 
@@ -113,7 +115,6 @@ class Orchestrator:
 
     def integrate(self, base_dir: Path) -> None:  # pragma: no cover - placeholder
         """Integrate per-port files into duct aggregates."""
-        from .aggregate import integrate_run, RunConfig
         import math
         from .geometry import Geometry, r_ratio, beta_from_geometry
         from dataclasses import fields as dataclass_fields
@@ -196,7 +197,6 @@ class Orchestrator:
         from kielproc_gui_adapter import process_legacy_parsed_csv
         from kielproc.physics import map_qs_to_qt
         from kielproc.visuals import render_velocity_heatmap
-        from .aggregate import _discover_pairs
         from .geometry import Geometry, r_ratio
 
         ports_dir = base_dir / "ports_csv"
@@ -233,7 +233,7 @@ class Orchestrator:
             self._pairs = pairs
             return
 
-        pairs, skipped = _discover_pairs(ports_dir, "*.csv")
+        pairs, skipped = discover_pairs(ports_dir, "*.csv")
         for name, reason in skipped:
             self.summary["warnings"].append(f"map {name}: {reason}")
         if not pairs:


### PR DESCRIPTION
## Summary
- Expose CSV pair discovery logic via new `discover_pairs` wrapper.
- Import and use `discover_pairs` in `run_easy`, replacing private helper usage.
- Ensure mapping step references the public API.

## Testing
- `pytest`
- `python - <<'PY'
import sys, types
sys.path.insert(0, '/workspace/KeilProc/kielproc_monorepo')
mod = types.ModuleType('kielproc_gui_adapter')
mod.process_legacy_parsed_csv = lambda *a, **k: None
sys.modules['kielproc_gui_adapter'] = mod
from pathlib import Path
from kielproc.run_easy import Orchestrator, RunInputs, SitePreset
site = SitePreset(name='dummy', geometry={'static_port_area_m2':1.0, 'total_port_area_m2':2.0}, instruments={}, defaults={})
inputs = RunInputs(src=Path('.'), site=site)
orc = Orchestrator(inputs)
orc.map(Path('test_base'))
print('map executed')
PY`

------
https://chatgpt.com/codex/tasks/task_b_68bc11618d58832295cb4249248a780e