### PR TITLE
Collect key run metrics in manifest

### DIFF
--- a/app/gui/run_easy_panel.py
+++ b/app/gui/run_easy_panel.py
@@ -424,10 +424,13 @@ class RunEasyPanel(ttk.Frame):
             tables = data.get("tables", [])
             plots = data.get("plots", [])
             self._append_log(f"Tables: {len(tables)}, Plots: {len(plots)}")
+            for t in tables:
+                self._append_log(f"table: {t}")
+            for p in plots:
+                self._append_log(f"plot: {p}")
             kv = data.get("key_values", {})
-            if kv:
-                kv_text = ", ".join(f"{k}={v}" for k, v in kv.items())
-                self._append_log(kv_text)
+            for k, v in kv.items():
+                self._append_log(f"{k}={v}")
         except Exception:
             self._append_log("Summary unavailable.")
 

--- a/kielproc_monorepo/kielproc/__init__.py
+++ b/kielproc_monorepo/kielproc/__init__.py
@@ -24,6 +24,7 @@ from .geometry import (
     beta_from_geometry,
 )
 from .legacy_results import ResultsConfig, compute_results as compute_legacy_results
+from .run_easy import SitePreset, RunInputs, OneClickError, Orchestrator, run_easy_legacy
 
 __all__ = [
     "__version__",
@@ -38,4 +39,5 @@ __all__ = [
     "Geometry", "duct_area", "throat_area", "r_ratio", "beta_from_geometry",
     "RunConfig", "integrate_run",
     "ResultsConfig", "compute_legacy_results",
+    "SitePreset", "RunInputs", "OneClickError", "Orchestrator", "run_easy_legacy",
 ]

--- a/kielproc_monorepo/kielproc/run_easy.py
+++ b/kielproc_monorepo/kielproc/run_easy.py
@@ -181,6 +181,11 @@ class Orchestrator:
             "q_t_pa": res.get("duct", {}).get("q_t_pa"),
             "delta_p_vent_est_pa": res.get("duct", {}).get("delta_p_vent_est_pa"),
         }
+        if area_ratio is not None:
+            ref_block["r"] = area_ratio
+        if beta is not None:
+            ref_block["beta"] = beta
+        self._venturi = {"r": area_ratio, "beta": beta}
         ref_json = outdir / "reference_block.json"
         ref_json.write_text(json.dumps(ref_block, indent=2))
 
@@ -322,6 +327,7 @@ class Orchestrator:
             if res.get("blocks_info"):
                 b0 = res["blocks_info"][0]
                 self._alpha_beta = {"alpha": b0.get("alpha"), "beta": b0.get("beta")}
+                self._lag = b0.get("lag_samples")
         except Exception as e:
             if self.strict:
                 raise OneClickError(f"fit: {e}")
@@ -434,24 +440,55 @@ class Orchestrator:
         self.report(out)
 
         # build manifest of outputs
-        tables = [str(p) for p in self.artifacts if p.suffix in {".csv", ".json"}]
-        plots = [str(p) for p in self.artifacts if p.suffix in {".png", ".pdf", ".svg"}]
-        key_vals: Dict[str, float] = {}
-        ref = next((p for p in self.artifacts if p.name == "reference_block.json"), None)
-        if ref and ref.exists():
+        tables = [str(p) for p in self.artifacts if p.suffix in {'.csv', '.json'}]
+        plots = [str(p) for p in self.artifacts if p.suffix in {'.png', '.pdf', '.svg'}]
+        key_vals: Dict[str, object] = {}
+        pooled = next((p for p in self.artifacts if p.name == 'alpha_beta_pooled.json'), None)
+        if pooled and pooled.exists():
             try:
-                ref_data = json.loads(ref.read_text())
-                for k in ("q_s_pa", "q_t_pa", "delta_p_vent_est_pa"):
-                    v = ref_data.get(k)
+                data = json.loads(pooled.read_text())
+                for k in ('alpha', 'beta'):
+                    v = data.get(k)
                     if v is not None:
                         key_vals[k] = v
             except Exception:
                 pass
-        if getattr(self, "_alpha_beta", None):
+        elif getattr(self, '_alpha_beta', None):
             key_vals.update({k: v for k, v in self._alpha_beta.items() if v is not None})
-
-        manifest = {"tables": tables, "plots": plots, "key_values": key_vals}
-        manifest_path = out / "summary.json"
+        if getattr(self, '_lag', None) is not None:
+            key_vals['lag_samples'] = self._lag
+        ref = next((p for p in self.artifacts if p.name == 'reference_block.json'), None)
+        if ref and ref.exists():
+            try:
+                ref_data = json.loads(ref.read_text())
+                mapping = {
+                    'q_s_pa': 'q_s_pa',
+                    'q_t_pa': 'q_t_pa',
+                    'delta_p_vent_est_pa': 'delta_p_vent_est_pa',
+                    'r': 'venturi_r',
+                    'beta': 'venturi_beta',
+                }
+                for src_key, dst_key in mapping.items():
+                    v = ref_data.get(src_key)
+                    if v is not None:
+                        key_vals[dst_key] = v
+            except Exception:
+                pass
+        span_file = next((p for p in self.artifacts if p.suffix == '.json' and ('setpoint' in p.name.lower() or 'span' in p.name.lower())), None)
+        if span_file and span_file.exists():
+            try:
+                span_data = json.loads(span_file.read_text())
+                if isinstance(span_data, dict):
+                    span = span_data.get('span')
+                    if span is not None:
+                        key_vals['transmitter_span'] = span
+                    mapping = span_data.get('mapping')
+                    if mapping is not None:
+                        key_vals['transmitter_setpoints'] = mapping
+            except Exception:
+                pass
+        manifest = {'tables': tables, 'plots': plots, 'key_values': key_vals}
+        manifest_path = out / 'summary.json'
         manifest_path.write_text(json.dumps(manifest, indent=2))
         self.artifacts.append(manifest_path)
 

--- a/kielproc_monorepo/kielproc/run_easy.py
+++ b/kielproc_monorepo/kielproc/run_easy.py
@@ -12,7 +12,7 @@ exercised in isolation.
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Dict, List, Callable
+from typing import Optional, Callable
 import json
 import time
 
@@ -52,7 +52,7 @@ class Orchestrator:
     def __init__(self, run: RunInputs, progress_cb: Optional[Callable[[str], None]] = None):
         self.run = run
         self.artifacts: list[Path] = []
-        self.summary: Dict = {"warnings": [], "errors": []}
+        self.summary: dict[str, list[str]] = {"warnings": [], "errors": []}
         self._progress_cb = progress_cb
         # strict mode: escalate critical-path issues to hard failures
         # enabled via RunInputs defaults (see run_easy_legacy signature)
@@ -69,7 +69,7 @@ class Orchestrator:
         # Assume system clock already set to NZT to avoid tz deps.
         return time.strftime("%Y%m%d_%H%M")
 
-    def _mkdirs(self, base: Path) -> Dict[str, Path]:
+    def _mkdirs(self, base: Path) -> dict[str, Path]:
         base.mkdir(parents=True, exist_ok=True)
         ports = base / "ports_csv"
         ports.mkdir(exist_ok=True)
@@ -440,9 +440,9 @@ class Orchestrator:
         self.report(out)
 
         # build manifest of outputs
-        tables = [str(p) for p in self.artifacts if p.suffix in {'.csv', '.json'}]
-        plots = [str(p) for p in self.artifacts if p.suffix in {'.png', '.pdf', '.svg'}]
-        key_vals: Dict[str, object] = {}
+        tables = [str(p) for p in self.artifacts if p.suffix in {".csv", ".json"}]
+        plots = [str(p) for p in self.artifacts if p.suffix in {".png", ".pdf", ".svg"}]
+        key_vals: dict[str, object] = {}
         pooled = next((p for p in self.artifacts if p.name == 'alpha_beta_pooled.json'), None)
         if pooled and pooled.exists():
             try:
@@ -509,7 +509,7 @@ def run_easy_legacy(
     output_base: Optional[Path] = None,
     progress_cb: Optional[Callable[[str], None]] = None,
     strict: bool = False,
-) -> tuple[Path, Dict, List[str]]:
+) -> tuple[Path, dict, list[str]]:
     """Run the full pipeline for a legacy workbook using ``SitePreset`` defaults.
 
     Returns


### PR DESCRIPTION
## Summary
- capture pooled translation parameters, venturi ratios and other key metrics in run summary
- log tables, plots and key values from summary.json in the Run Easy GUI panel

## Testing
- `python3 -m pytest` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_b_68bc13b93d8c83228a8c5d5459df7e20