### PR TITLE
Initialize pair list in Orchestrator

### DIFF
--- a/kielproc_monorepo/kielproc/run_easy.py
+++ b/kielproc_monorepo/kielproc/run_easy.py
@@ -53,6 +53,7 @@ class Orchestrator:
         self.run = run
         self.artifacts: list[Path] = []
         self.summary: dict[str, list[str]] = {"warnings": [], "errors": []}
+        self._pairs: list[tuple[str, Path]] = []
         self._progress_cb = progress_cb
         # strict mode: escalate critical-path issues to hard failures
         # enabled via RunInputs defaults (see run_easy_legacy signature)


### PR DESCRIPTION
## Summary
- initialize `_pairs` list during `Orchestrator` construction so later stages can access it directly

## Testing
- `pip install -r kielproc_monorepo/requirements.txt -c kielproc_monorepo/constraints.txt`
- `cd kielproc_monorepo && pytest`

------
https://chatgpt.com/codex/tasks/task_b_68bcb89e276c8322bfb847b46d27114a