### PR TITLE
Add unit conversion and end-to-end pipeline tests

### DIFF
--- a/kielproc_monorepo/tests/test_fit_setpoints_plot.py
+++ b/kielproc_monorepo/tests/test_fit_setpoints_plot.py
@@ -1,0 +1,57 @@
+import numpy as np
+import numpy as np
+import pandas as pd
+import pytest
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(ROOT))
+
+from kielproc.gui_adapter import fit_alpha_beta
+from kielproc.setpoints import find_optimal_transmitter_span
+from kielproc.report import plot_alignment
+
+
+def test_fit_alpha_beta_with_qa_gate(tmp_path):
+    df = pd.DataFrame({
+        "mapped_ref": [0.0, 1.0, 2.0],
+        "piccolo": [1.0, 3.0, 5.0],
+        "pN": [100.0, 100.0, 100.0],
+        "pS": [100.0, 100.0, 100.0],
+        "pE": [100.0, 100.0, 100.0],
+        "pW": [100.0, 100.0, 100.0],
+        "q_mean": [100.0, 100.0, 100.0],
+    })
+    outdir = tmp_path / "fit"
+    res = fit_alpha_beta({"blk": df}, "mapped_ref", "piccolo", 1.0, 10, outdir)
+    info = res["blocks_info"][0]
+    assert info["alpha"] == pytest.approx(2.0)
+    assert info["beta"] == pytest.approx(1.0)
+
+    df_bad = df.copy()
+    df_bad["pN"] = [500.0, 100.0, 100.0]
+    with pytest.raises(RuntimeError):
+        fit_alpha_beta({"bad": df_bad}, "mapped_ref", "piccolo", 1.0, 10, tmp_path / "bad", qa_gate_opp=0.01, qa_gate_w=1.0)
+
+
+def test_find_optimal_transmitter_span():
+    x = [0, 1, 2, 3, 4]
+    y = [1 + 2 * xi for xi in x]
+    opt = find_optimal_transmitter_span(x, y, slope_sign=+1)
+    assert opt.slope == pytest.approx(2.0)
+    assert opt.intercept == pytest.approx(1.0)
+    assert opt.x_low == pytest.approx(0.0)
+    assert opt.x_high == pytest.approx(2.0)
+    assert opt.setpoints["span"]["x_low"] == pytest.approx(0.0)
+
+
+def test_plot_alignment_headless(tmp_path):
+    import matplotlib
+    matplotlib.use("Agg")
+    t = np.array([0.0, 1.0, 2.0])
+    ref = np.array([0.0, 1.0, 2.0])
+    picc = np.array([0.1, 1.1, 2.1])
+    shifted = np.array([0.1, 1.1, 2.1])
+    png = plot_alignment(tmp_path, t, ref, picc, shifted, title="align", stem="test")
+    assert Path(png).exists()

--- a/kielproc_monorepo/tests/test_one_click_e2e.py
+++ b/kielproc_monorepo/tests/test_one_click_e2e.py
@@ -1,0 +1,70 @@
+import json
+from pathlib import Path
+import sys
+
+import pandas as pd
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "kielproc_monorepo"))
+
+from kielproc import cli
+from kielproc.run_easy import SitePreset
+import tools.legacy_parser.legacy_parser.parser as parser_mod
+
+
+def test_one_click_e2e(tmp_path, monkeypatch, capsys):
+    geom = {
+        "duct_height_m": 1.0,
+        "duct_width_m": 1.0,
+        "static_port_area_m2": 1.0,
+        "total_port_area_m2": 2.0,
+        "throat_width_m": 0.5,
+        "throat_height_m": 0.5,
+    }
+    site = SitePreset(name="TestSite", geometry=geom, instruments={"vp_unit": "Pa", "temp_unit": "C"}, defaults={})
+    monkeypatch.setitem(cli.PRESETS, "TestSite", site)
+
+    def fake_parse(xlsx_path, out_dir, return_mode="files", **kwargs):
+        out_dir.mkdir(parents=True, exist_ok=True)
+        df = pd.read_excel(xlsx_path, sheet_name="P1", header=0)
+        df = df.iloc[1:].reset_index(drop=True)
+        df.columns = ["Time", "Static", "VP", "Temperature", "Piccolo", "pN", "pS", "pE", "pW", "q_mean"]
+        csv_path = out_dir / f"{xlsx_path.stem}__P1.csv"
+        df.to_csv(csv_path, index=False)
+        summary = {"sheets": [{"sheet": "P1", "csv_path": str(csv_path), "mode": "vertical"}]}
+        (out_dir / f"{xlsx_path.stem}__parse_summary.json").write_text(json.dumps(summary))
+        return summary
+
+    monkeypatch.setattr(parser_mod, "parse_legacy_workbook", fake_parse)
+
+    beta = 0.5
+    r = 0.5
+    c = (1 - beta**4) * (r**2)
+    vp = [1.0, 2.0, 3.0]
+    deltp = [c * v for v in vp]
+    piccolo = [2 * d + 1 for d in deltp]
+
+    cols = ["Time", "Static Pressure", "Velocity Pressure", "Temperature", "Piccolo", "pN", "pS", "pE", "pW", "q_mean"]
+    units = ["s", "Pa", "Pa", "K", "", "", "", "", "", ""]
+    data = [
+        [0, 101325, vp[0], 293.15, piccolo[0], 1000, 1000, 1000, 1000, 1000],
+        [1, 101325, vp[1], 293.15, piccolo[1], 1000, 1000, 1000, 1000, 1000],
+        [2, 101325, vp[2], 293.15, piccolo[2], 1000, 1000, 1000, 1000, 1000],
+    ]
+    df = pd.DataFrame([cols, units] + data)
+    wb = tmp_path / "book.xlsx"
+    with pd.ExcelWriter(wb) as xls:
+        df.to_excel(xls, sheet_name="P1", index=False, header=False)
+
+    args = ["one-click", str(wb), "--site", "TestSite"]
+    cli.main(args)
+    out = json.loads(capsys.readouterr().out)
+    assert out["ok"] is True
+    art_names = [Path(a).name for a in out["artifacts"]]
+    assert "alpha_beta_by_block.csv" in art_names
+    fit_csv = Path(out["out_dir"]) / "_fit" / "alpha_beta_by_block.csv"
+    tbl = pd.read_csv(fit_csv)
+    assert tbl["alpha"].iloc[0] == pytest.approx(2.0, rel=1e-5)
+    assert tbl["beta"].iloc[0] == pytest.approx(1.0, rel=1e-5)

--- a/kielproc_monorepo/tests/test_units_and_integration.py
+++ b/kielproc_monorepo/tests/test_units_and_integration.py
@@ -1,0 +1,41 @@
+import pandas as pd
+import pytest
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "kielproc_monorepo" / "tools" / "legacy_parser"))
+from legacy_parser.parser import _sanitize_headers_and_units
+from kielproc.aggregate import _normalize_df, RunConfig, integrate_run
+
+
+def test_header_unit_conversions():
+    df = pd.DataFrame({
+        "Temperature (K)": [300.0, 310.0],
+        "Static_gauge (kPa)": [1.0, 1.0],
+        "Baro (kPa)": [100.0, 100.0],
+        "VP": [5.0, 5.0],
+    })
+    san = _sanitize_headers_and_units(df)
+    assert "Temperature" in san.columns
+    assert san["Temperature"].iloc[0] == pytest.approx(26.85, abs=1e-2)
+    assert san["Static_gauge"].iloc[0] == pytest.approx(1000.0)
+    assert san["Baro"].iloc[0] == pytest.approx(100000.0)
+    norm, meta = _normalize_df(san, None)
+    assert norm["Static_abs_Pa"].iloc[0] == pytest.approx(101000.0)
+
+
+def test_integration_missing_ports(tmp_path):
+    for i in range(1, 8):  # create seven ports P1..P7
+        df = pd.DataFrame({
+            "Time": [0, 1, 2],
+            "Static": [101325.0, 101325.0, 101325.0],
+            "VP": [1.0, 1.0, 1.0],
+            "Temperature": [20.0, 20.0, 20.0],
+        })
+        df.to_csv(tmp_path / f"P{i}.csv", index=False)
+    cfg = RunConfig(height_m=1.0, width_m=1.0, weights={f"P{j}": 1.0 for j in range(1, 9)})
+    res = integrate_run(tmp_path, cfg, area_ratio=1.0)
+    assert {f"P{i}" for i in range(1,8)} == set(res["per_port"]["Port"])
+    assert res["duct"]["q_s_pa"] == pytest.approx(1.0)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 pythonpath = .
 addopts = -q
-testpaths = tests
+testpaths = tests kielproc_monorepo/tests


### PR DESCRIPTION
## Summary
- cover header-driven unit conversions and integration with missing ports
- add tests for Deming+lag fit, setpoint span search, and headless plotting
- golden one-click run from synthetic workbook verifying alpha/beta outputs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68bcda1e535083229af662a1d31f20d7