### PR TITLE
Refactor Run Easy imports and tidy packaging

### DIFF
--- a/kielproc/run_easy.py
+++ b/kielproc/run_easy.py
@@ -17,6 +17,12 @@ import json
 import time
 
 from .aggregate import integrate_run, RunConfig, discover_pairs
+from .gui_adapter import (
+    process_legacy_parsed_csv,
+    fit_alpha_beta,
+    translate_piccolo,
+    legacy_results_from_csv,
+)
 
 NZT = "Pacific/Auckland"
 
@@ -200,7 +206,6 @@ class Orchestrator:
     
     def map(self, base_dir: Path) -> None:  # pragma: no cover - placeholder
         """Build velocity maps from integrated data."""
-        from .gui_adapter import process_legacy_parsed_csv
         from .physics import map_qs_to_qt
         from .visuals import render_velocity_heatmap
         from .geometry import Geometry, r_ratio
@@ -296,7 +301,6 @@ class Orchestrator:
 
     def fit(self, base_dir: Path) -> None:  # pragma: no cover - placeholder
         """Fit calibration models."""
-        from .gui_adapter import fit_alpha_beta
 
         mapped = getattr(self, "_mapped_csvs", [])
         if not mapped:
@@ -336,7 +340,6 @@ class Orchestrator:
 
     def translate(self, base_dir: Path) -> None:  # pragma: no cover - placeholder
         """Generate control-system lookup tables."""
-        from .gui_adapter import translate_piccolo
 
         if not getattr(self, "_alpha_beta", None) or not getattr(self, "_mapped_csvs", None):
             msg = "translate: missing fit results or mapped data"
@@ -366,7 +369,6 @@ class Orchestrator:
 
     def report(self, base_dir: Path) -> None:  # pragma: no cover - placeholder
         """Emit consolidated HTML/PDF reports."""
-        from .gui_adapter import legacy_results_from_csv
         from .legacy_results import ResultsConfig
         import math
 

--- a/kielproc_monorepo/pyproject.toml
+++ b/kielproc_monorepo/pyproject.toml
@@ -14,22 +14,16 @@ dependencies = [
     "pandas>=2.0",
     "matplotlib>=3.8",
     "openpyxl>=3.1",
-    "xlrd>=2.0",
 ]
 
 [project.optional-dependencies]
-gui = [
-    "tk>=0.1",
-    "keilproc-oneclick>=0.1.0",
-]
+gui = []
 
 [project.scripts]
 kielproc = "kielproc.cli:main"
 
-[tool.setuptools.packages.find]
-where = ["."]
-include = ["kielproc"]
-exclude = []
+[tool.setuptools]
+package-dir = {"" = ".."}
 
-[tool.pytest.ini_options]
-pythonpath = ["."]
+[tool.setuptools.packages.find]
+include = ["kielproc"]


### PR DESCRIPTION
## Summary
- Centralize Run Easy's adapter utilities with a single import from `gui_adapter`.
- Simplify pyproject dependencies and packaging config to only include the `kielproc` package.

## Testing
- `pip install -e kielproc_monorepo`
- `python - <<'PY'
import kielproc, os
print(kielproc.__file__)
print('PYTHONPATH' in os.environ)
PY`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68bcfacda414832288dfac98d0c02087