### PR TITLE
Clarify placeholder error handling in legacy processing

### DIFF
--- a/app/gui/run_easy_panel.py
+++ b/app/gui/run_easy_panel.py
@@ -341,14 +341,14 @@ class RunEasyPanel(ttk.Frame):
             try:
                 d = float(pgeom["duct_diameter_m"])
                 pgeom["duct_area_m2"] = math.pi * (d**2) / 4.0
-            except Exception:
-                pass
+            except Exception as e:
+                self._append_log(f"⚠️ Invalid duct diameter: {e}")
         if ("throat_area_m2" not in pgeom) and (pgeom.get("throat_diameter_m")):
             try:
                 dt = float(pgeom["throat_diameter_m"])
                 pgeom["throat_area_m2"] = math.pi * (dt**2) / 4.0
-            except Exception:
-                pass
+            except Exception as e:
+                self._append_log(f"⚠️ Invalid throat diameter: {e}")
 
         if geom_override or defaults_override:
             pgeom.update(geom_override)
@@ -380,8 +380,8 @@ class RunEasyPanel(ttk.Frame):
             r = float(As) / float(At_ports)
             beta = float(beta_override) if beta_override is not None else (float(At) / float(A1)) ** 0.5
             self._append_log(f"Derived: r={r:.4g}, β={beta:.4g}")
-        except Exception:
-            pass
+        except Exception as e:
+            self._append_log(f"⚠️ Unable to derive r/β: {e}")
 
         self._queue = queue.Queue()
         self._runner = _Runner(src, preset, baro, stamp, out_dir, self._queue)

--- a/kielproc/io.py
+++ b/kielproc/io.py
@@ -8,13 +8,17 @@ LEGACY_TIME_COLS = ["Time", "Timestamp", "t", "time"]
 
 def load_legacy_excel(path: Path, sheet=None) -> dict[str, pd.DataFrame]:
     xls = pd.ExcelFile(path)
-    frames = {}
+    frames: dict[str, pd.DataFrame] = {}
     for nm in xls.sheet_names if sheet is None else [sheet]:
         try:
-            df = xls.parse(nm)
-            frames[nm] = df
+            frames[nm] = xls.parse(nm)
         except Exception:
-            pass
+            # Legacy workbooks occasionally contain charts or other objects
+            # that ``pandas`` cannot parse into a ``DataFrame``.  These are
+            # not fatal for the calling code, so simply skip over them rather
+            # than swallowing the exception with ``pass`` which obscures the
+            # control flow.
+            continue
     return frames
 
 def load_logger_csv(path: Path, sp_col: str, vp_col: str, time_col: str | None = None) -> pd.DataFrame:

--- a/kielproc_monorepo/tools/legacy_parser/legacy_parser/parser.py
+++ b/kielproc_monorepo/tools/legacy_parser/legacy_parser/parser.py
@@ -20,10 +20,9 @@ def _sanitize_headers_and_units(df: pd.DataFrame) -> pd.DataFrame:
             if re.search(r"(?i)(kelvin|\(k\)|_k\b|\bk\b)", c):
                 out["Temperature"] = pd.to_numeric(out[c], errors="coerce") - 273.15
                 if c != "Temperature":
-                    try:
-                        out.drop(columns=[c], inplace=True)
-                    except Exception:
-                        pass
+                    # ``errors='ignore'`` avoids an exception if the column was
+                    # already removed by earlier normalization steps.
+                    out.drop(columns=[c], inplace=True, errors="ignore")
                 break
     # Static: header-driven units and gauge/absolute only (no magnitude heuristic).
     def _unit_scale(colname: str) -> float:
@@ -54,10 +53,7 @@ def _sanitize_headers_and_units(df: pd.DataFrame) -> pd.DataFrame:
             if re.search(r"(?i)\bbaro|barometric|ambient", c):
                 out["Baro"] = pd.to_numeric(out[c], errors="coerce") * _unit_scale(c)
                 if c != "Baro":
-                    try:
-                        out.drop(columns=[c], inplace=True)
-                    except Exception:
-                        pass
+                    out.drop(columns=[c], inplace=True, errors="ignore")
     return out
 
 


### PR DESCRIPTION
## Summary
- Skip unreadable sheets when loading legacy Excel files instead of swallowing exceptions
- Replace silent exception handling with informative logging in Run Easy panel
- Simplify header sanitation by dropping columns with `errors="ignore"`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bd030f5e348322bf172ba8e70ac420