### PR TITLE
Expose discover_pairs and fix gui adapter imports

### DIFF
--- a/kielproc/__init__.py
+++ b/kielproc/__init__.py
@@ -15,7 +15,7 @@ from .io import load_legacy_excel, load_logger_csv, unify_schema
 from .translate import compute_translation_table, apply_translation
 from .report import write_summary_tables, plot_alignment
 from .qa import qa_indices
-from .aggregate import RunConfig, integrate_run
+from .aggregate import RunConfig, integrate_run, discover_pairs
 from .geometry import (
     Geometry,
     duct_area,
@@ -37,7 +37,7 @@ __all__ = [
     "compute_translation_table", "apply_translation",
     "write_summary_tables", "plot_alignment", "qa_indices",
     "Geometry", "duct_area", "throat_area", "r_ratio", "beta_from_geometry",
-    "RunConfig", "integrate_run",
+    "RunConfig", "integrate_run", "discover_pairs",
     "ResultsConfig", "compute_legacy_results",
     "SitePreset", "RunInputs", "OneClickError", "Orchestrator", "run_easy_legacy",
 ]

--- a/kielproc_monorepo/tests/test_fit_setpoints_plot.py
+++ b/kielproc_monorepo/tests/test_fit_setpoints_plot.py
@@ -1,12 +1,7 @@
 import numpy as np
-import numpy as np
 import pandas as pd
 import pytest
 from pathlib import Path
-import sys
-
-ROOT = Path(__file__).resolve().parents[2]
-sys.path.append(str(ROOT))
 
 from kielproc.gui_adapter import fit_alpha_beta
 from kielproc.setpoints import find_optimal_transmitter_span


### PR DESCRIPTION
## Summary
- Export `discover_pairs` from the package API.
- Clean up tests to import `kielproc.gui_adapter` using package paths.

## Testing
- `ruff check kielproc/__init__.py kielproc_monorepo/tests/test_fit_setpoints_plot.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68bd050b54908322832b4fe2423a9374