### PR TITLE
Ensure deterministic key values in summary manifest

### DIFF
--- a/kielproc/run_easy.py
+++ b/kielproc/run_easy.py
@@ -507,6 +507,17 @@ class Orchestrator:
                             key_vals['transmitter_setpoints'] = mapping
             except Exception:
                 pass
+        required_keys = [
+            "alpha",
+            "beta",
+            "lag_samples",
+            "venturi_r",
+            "venturi_beta",
+            "transmitter_span",
+            "transmitter_setpoints",
+        ]
+        key_vals = {k: key_vals.get(k) for k in required_keys}
+
         manifest = {'tables': tables, 'plots': plots, 'key_values': key_vals}
         manifest_path = out / 'summary.json'
         manifest_path.write_text(json.dumps(manifest, indent=2))

--- a/tests/test_run_easy_summary.py
+++ b/tests/test_run_easy_summary.py
@@ -1,0 +1,44 @@
+import json
+from pathlib import Path
+
+from kielproc.run_easy import Orchestrator, RunInputs, SitePreset
+
+
+class DummyOrchestrator(Orchestrator):
+    def parse(self, ports_dir: Path) -> None:
+        pass
+
+    def integrate(self, base_dir: Path) -> None:
+        pass
+
+    def map(self, base_dir: Path) -> None:
+        pass
+
+    def fit(self, base_dir: Path) -> None:
+        pass
+
+    def translate(self, base_dir: Path) -> None:
+        pass
+
+    def report(self, base_dir: Path) -> None:
+        pass
+
+
+def test_summary_contains_required_keys(tmp_path):
+    src = tmp_path / "book.xlsx"
+    src.write_text("")
+    site = SitePreset(name="Dummy", geometry={}, instruments={}, defaults={})
+    run = RunInputs(src=src, site=site, output_base=tmp_path)
+    orch = DummyOrchestrator(run)
+    out_dir = orch.run_all()
+    manifest = json.loads((out_dir / "summary.json").read_text())
+    expected_keys = {
+        "alpha": None,
+        "beta": None,
+        "lag_samples": None,
+        "venturi_r": None,
+        "venturi_beta": None,
+        "transmitter_span": None,
+        "transmitter_setpoints": None,
+    }
+    assert manifest["key_values"] == expected_keys


### PR DESCRIPTION
## Summary
- Normalize `summary.json` key_values by including required calibration and venturi fields, defaulting to `None`
- Add regression test ensuring summary manifest always includes expected keys

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bd0e9780748322afd39d4884b3b245