### PR TITLE
Fix barometric CLI flag in GUI fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ python -m pip install .
 ## Usage
 
 ```bash
-kielproc one-click <workbook> --site <Preset> --baro-override <Pa>
+kielproc one-click <workbook> --site <Preset> --baro <Pa>
 ```
 
 Running `kielproc one-click` executes the full SOP:

--- a/kielproc_monorepo/README.md
+++ b/kielproc_monorepo/README.md
@@ -12,7 +12,7 @@ python -m pip install .
 ## Usage
 
 ```bash
-kielproc one-click <workbook> --site <Preset> --baro-override <Pa>
+kielproc one-click <workbook> --site <Preset> --baro <Pa>
 ```
 
 Running `kielproc one-click` executes the full pipeline:

--- a/runeasy_gui.py
+++ b/runeasy_gui.py
@@ -125,7 +125,7 @@ def call_runeasy_api_or_cli(input_path: Path, site: Optional[str], baro: Optiona
     if site:
         cmd += ["--site", site]
     if baro:
-        cmd += ["--baro-override", baro]
+        cmd += ["--baro", baro]
     logfn("Running CLI: " + " ".join(cmd))
     try:
         proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=False)


### PR DESCRIPTION
## Summary
- ensure GUI fallback passes `--baro` to `kielproc` CLI
- align README docs with `--baro` flag

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68bd3d01120c8322a06f410530bddaf7