### PR TITLE
Remove tk dependency and clarify optional xlrd

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ From the repository root:
 python -m pip install .
 ```
 
+If you need to parse legacy `.xls` workbooks, also install `xlrd<2.0`. Modern
+`.xlsx` files are supported out of the box.
+
 ## Usage
 
 ### CLI

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ numpy>=1.24
 pandas>=2.0
 matplotlib>=3.8
 openpyxl>=3.1
-xlrd<2.0  # for legacy .xls
-tk>=0.1  # Tk bindings for GUI widgets
+xlrd<2.0  # (optional) only if you truly need legacy .xls


### PR DESCRIPTION
## Summary
- Drop incorrect `tk` dependency
- Clarify `xlrd` as optional for legacy `.xls`

## Testing
- `python -m nox -s tests smoke`


------
https://chatgpt.com/codex/tasks/task_b_68bd3f3fa2548322acfb22716ca5aaad