### PR TITLE
fix: point installer at RunEasy-GUI

### DIFF
--- a/tools/installer/keilproc.iss
+++ b/tools/installer/keilproc.iss
@@ -10,11 +10,11 @@ Compression=lzma
 SolidCompression=yes
 
 [Files]
-Source: "..\..\dist\kielproc-gui\kielproc-gui.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "..\..\dist\RunEasy-GUI.exe"; DestDir: "{app}"; Flags: ignoreversion
 
 [Icons]
-Name: "{group}\KielProc GUI"; Filename: "{app}\kielproc-gui.exe"
-Name: "{commondesktop}\KielProc GUI"; Filename: "{app}\kielproc-gui.exe"; Tasks: desktopicon
+Name: "{group}\RunEasy"; Filename: "{app}\RunEasy-GUI.exe"
+Name: "{commondesktop}\RunEasy"; Filename: "{app}\RunEasy-GUI.exe"; Tasks: desktopicon
 
 [Tasks]
 Name: desktopicon; Description: "Create a desktop shortcut"; GroupDescription: "Additional icons:"


### PR DESCRIPTION
## Summary
- update Windows installer script to include RunEasy-GUI.exe and create RunEasy shortcuts

## Testing
- `nox -s tests`


------
https://chatgpt.com/codex/tasks/task_b_68bd400f8c908322a7e9f949f4149638