### PR TITLE
Include QA gates and run inputs in summary manifest

### DIFF
--- a/tests/test_run_easy_summary.py
+++ b/tests/test_run_easy_summary.py
@@ -42,3 +42,12 @@ def test_summary_contains_required_keys(tmp_path):
         "transmitter_setpoints": None,
     }
     assert manifest["key_values"] == expected_keys
+    assert manifest["qa_gates"] == {"delta_opp_max": 0.01, "w_max": 0.002}
+    expected_inputs = {
+        "baro_override_Pa": None,
+        "site": "Dummy",
+        "r": None,
+        "beta": None,
+        "reference": None,
+    }
+    assert manifest["inputs"] == expected_inputs


### PR DESCRIPTION
## Summary
- expose default QA gates and skipped file records in summary manifest
- echo barometric override, site, venturi geometry, and reference selection in manifest inputs
- add regression tests for new manifest fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bd47ae3b2883229b1179442090177b