### PR TITLE
Localize run stamp to NZ timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ python -m pip install .
 If you need to parse legacy `.xls` workbooks, also install `xlrd<2.0`. Modern
 `.xlsx` files are supported out of the box.
 
+Timestamps are localized to New Zealand time using `tzdata`, which is installed
+as part of the package dependencies.
+
 ## Usage
 
 ### CLI

--- a/kielproc/run_easy.py
+++ b/kielproc/run_easy.py
@@ -11,11 +11,12 @@ exercised in isolation.
 """
 
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import Optional, Callable
 import dataclasses
 import json
-import time
+from zoneinfo import ZoneInfo
 
 from .aggregate import integrate_run, RunConfig, discover_pairs
 from .gui_adapter import (
@@ -76,8 +77,8 @@ class Orchestrator:
     def _stamp(self) -> str:
         if self.run.run_stamp:
             return self.run.run_stamp
-        # Assume system clock already set to NZT to avoid tz deps.
-        return time.strftime("%Y%m%d_%H%M")
+        # Localize to NZT explicitly to avoid relying on system timezone.
+        return datetime.now(ZoneInfo(NZT)).strftime("%Y%m%d_%H%M")
 
     def _mkdirs(self, base: Path) -> dict[str, Path]:
         base.mkdir(parents=True, exist_ok=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "pandas>=2.0",
     "matplotlib>=3.8",
     "openpyxl>=3.1",
+    "tzdata",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas>=2.0
 matplotlib>=3.8
 openpyxl>=3.1
 xlrd<2.0  # (optional) only if you truly need legacy .xls
+tzdata


### PR DESCRIPTION
## Summary
- Use `datetime` with `zoneinfo.ZoneInfo("Pacific/Auckland")` for run directory stamps
- Add `tzdata` runtime dependency and document timezone localization

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68bd493480448322a75c322f768c9964