### PR TITLE
feat: add strict mode flag

### DIFF
--- a/kielproc/cli.py
+++ b/kielproc/cli.py
@@ -28,6 +28,7 @@ def build_parser():
     oc.add_argument("--stamp", type=str, default=None, help="Override run stamp YYYYMMDD_HHMM (NZT)")
     oc.add_argument("--out", type=Path, default=None, help="Output base directory (RUN_* will be created here)")
     oc.add_argument("--bundle", action="store_true", help="Zip run directory into RUN_*__bundle.zip")
+    oc.add_argument("--strict", action="store_true", help="Fail fast on missing/invalid stages")
 
     i0 = sub.add_parser("results", help="Report legacy-style results from a logger CSV")
     i0.add_argument("--csv", required=True, help="Input logger CSV path")
@@ -119,6 +120,7 @@ def main(argv=None):
             baro_override_Pa=a.baro,
             run_stamp=a.stamp,
             output_base=a.out,
+            strict=a.strict,
         )
         bundle_zip = None
         if a.bundle:

--- a/tests/test_cli_one_click.py
+++ b/tests/test_cli_one_click.py
@@ -7,9 +7,18 @@ from kielproc import cli
 def test_cli_one_click(monkeypatch, tmp_path, capsys):
     out_dir = tmp_path / "out"
 
-    def fake_run(src, site, baro_override_Pa=None, run_stamp=None, *, output_base=None):
+    def fake_run(
+        src,
+        site,
+        baro_override_Pa=None,
+        run_stamp=None,
+        *,
+        output_base=None,
+        strict=False,
+    ):
         assert src == Path(tmp_path / "book.xlsx")
         assert output_base is None
+        assert strict is False
         return out_dir, {"warnings": ["w"], "errors": []}, [str(out_dir / "a.csv")]
 
     monkeypatch.setattr(cli, "run_easy_legacy", fake_run)
@@ -28,7 +37,16 @@ def test_cli_one_click_bundle(monkeypatch, tmp_path, capsys):
     out_dir.mkdir()
     (out_dir / "dummy.txt").write_text("x")
 
-    def fake_run(src, site, baro_override_Pa=None, run_stamp=None, *, output_base=None):
+    def fake_run(
+        src,
+        site,
+        baro_override_Pa=None,
+        run_stamp=None,
+        *,
+        output_base=None,
+        strict=False,
+    ):
+        assert strict is False
         return out_dir, {"warnings": [], "errors": []}, []
 
     monkeypatch.setattr(cli, "run_easy_legacy", fake_run)
@@ -38,3 +56,33 @@ def test_cli_one_click_bundle(monkeypatch, tmp_path, capsys):
     data = json.loads(captured)
     bundle = Path(data["bundle_zip"])
     assert bundle.exists()
+
+
+def test_cli_one_click_strict(monkeypatch, tmp_path, capsys):
+    out_dir = tmp_path / "out"
+
+    def fake_run(
+        src,
+        site,
+        baro_override_Pa=None,
+        run_stamp=None,
+        *,
+        output_base=None,
+        strict=False,
+    ):
+        assert strict is True
+        return out_dir, {"warnings": [], "errors": []}, []
+
+    monkeypatch.setattr(cli, "run_easy_legacy", fake_run)
+    args = [
+        "one-click",
+        str(tmp_path / "book.xlsx"),
+        "--site",
+        "DefaultSite",
+        "--strict",
+    ]
+    cli.main(args)
+    captured = capsys.readouterr().out.strip()
+    data = json.loads(captured)
+    assert data["ok"] is True
+


### PR DESCRIPTION
## Summary
- add `--strict` flag to `one-click` CLI to fail fast on missing or invalid stages
- propagate `strict` to `run_easy_legacy`
- test CLI handling of `--strict`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bd4ffa91808322aedf3afbe6c31aa8