### PR TITLE
Expose stable run_all API

### DIFF
--- a/kielproc/__init__.py
+++ b/kielproc/__init__.py
@@ -24,7 +24,14 @@ from .geometry import (
     beta_from_geometry,
 )
 from .legacy_results import ResultsConfig, compute_results as compute_legacy_results
-from .run_easy import SitePreset, RunInputs, OneClickError, Orchestrator, run_easy_legacy
+from .run_easy import (
+    SitePreset,
+    RunInputs,
+    OneClickError,
+    Orchestrator,
+    run_easy_legacy,
+    run_all,
+)
 
 __all__ = [
     "__version__",
@@ -39,5 +46,5 @@ __all__ = [
     "Geometry", "duct_area", "throat_area", "r_ratio", "beta_from_geometry",
     "RunConfig", "integrate_run", "discover_pairs",
     "ResultsConfig", "compute_legacy_results",
-    "SitePreset", "RunInputs", "OneClickError", "Orchestrator", "run_easy_legacy",
+    "SitePreset", "RunInputs", "OneClickError", "Orchestrator", "run_easy_legacy", "run_all",
 ]

--- a/kielproc/run_easy.py
+++ b/kielproc/run_easy.py
@@ -641,10 +641,13 @@ def run_all(
     *,
     strict: bool = False,
 ):
-    """Convenience wrapper around :class:`Orchestrator`.
+    """Run the full pipeline for ``src`` and return details.
 
-    Parameters are forwarded to :class:`RunInputs`.  ``site`` may be a preset
-    name or a ``SitePreset`` instance.  Returns the run directory ``Path``.
+    Parameters are forwarded to :class:`RunInputs`. ``site`` may be a preset
+    name or a :class:`SitePreset` instance.  Returns a triple ``(run_dir,
+    summary, artifacts)`` where ``run_dir`` is the output directory ``Path``,
+    ``summary`` contains warning/error details, and ``artifacts`` is a list of
+    generated tables/plots.
     """
 
     if isinstance(site, str):
@@ -657,7 +660,9 @@ def run_all(
         Path(output_base) if output_base else None,
     )
     setattr(run, "strict", strict)
-    return Orchestrator(run).run_all()
+    orch = Orchestrator(run)
+    out = orch.run_all()
+    return out, orch.summary, [str(p) for p in orch.artifacts]
 
 
 # Convenience entry point -----------------------------------------------------

--- a/runeasy_gui.py
+++ b/runeasy_gui.py
@@ -6,7 +6,7 @@ Purpose
   • Single-window, operator-proof GUI to run the full SOP pipeline ("Run-Easy") with zero terminal use.
   • Shows key values (α, β, lag, venturi r & β, transmitter span & setpoints) and lists plots/tables from summary.json.
   • Double-click to open artifacts; preview PNGs inline; open run folder / bundle zip.
-  • API‑first (kielproc.run_easy.run_all); silent fallback to CLI `kielproc one-click`.
+  • API‑first (kielproc.run_all); silent fallback to CLI `kielproc one-click`.
 
 Nice-to-haves
   • Remembers last paths/site/baro/folder in a per-user config file.
@@ -112,24 +112,14 @@ def call_runeasy_api_or_cli(
     """Run via API first; fall back to CLI. Return RunResult."""
     # 1) API path
     try:
-        logfn("Using kielproc.run_easy API…")
-        from kielproc.run_easy import run_all  # now valid
-        rd = run_all(
+        logfn("Using kielproc.run_all API…")
+        from kielproc import run_all  # stable API
+        run_dir, smry, _ = run_all(
             str(input_path),
             site=(site or "DefaultSite"),
             baro_override=_try_float(baro),
             strict=strict,
         )
-        if isinstance(rd, (str, Path)):
-            run_dir = Path(rd)
-        elif isinstance(rd, dict):
-            p = rd.get("run_dir") or rd.get("output_dir") or rd.get("path")
-            run_dir = Path(p) if p else (_newest_run_dir(Path.cwd()) or None)
-        else:
-            run_dir = _newest_run_dir(Path.cwd())
-        if not run_dir:
-            raise RuntimeError("API finished but no RUN_* directory was found.")
-        smry = _read_text_json(Path(run_dir) / "summary.json")
         return RunResult(run_dir=Path(run_dir), summary=smry)
     except Exception as e:
         logfn(f"API path unavailable: {e}. Falling back to CLI…")

--- a/tests/test_run_all_api.py
+++ b/tests/test_run_all_api.py
@@ -1,0 +1,26 @@
+def test_run_all_returns_triple_and_artifacts(monkeypatch, tmp_path):
+    from kielproc import run_all
+    import kielproc.run_easy as run_easy
+
+    class StubOrchestrator:
+        def __init__(self, run, progress_cb=None):
+            self.run = run
+            self.summary = {"ok": True}
+            self.artifacts = [tmp_path / "a.txt"]
+            self.artifacts[0].write_text("")
+
+        def run_all(self):
+            out_dir = tmp_path / "RUN_123"
+            out_dir.mkdir()
+            return out_dir
+
+    monkeypatch.setattr(run_easy, "Orchestrator", StubOrchestrator)
+
+    src = tmp_path / "book.xlsx"
+    src.write_text("")
+    site = run_easy.SitePreset(name="Dummy", geometry={}, instruments={}, defaults={})
+    out, summary, artifacts = run_all(src, site=site, output_base=tmp_path)
+
+    assert out == tmp_path / "RUN_123"
+    assert summary == {"ok": True}
+    assert artifacts == [str(tmp_path / "a.txt")]


### PR DESCRIPTION
## Summary
- Make run_all return run directory, summary, and artifact list
- Re-export run_all at package root and use it in RunEasy GUI
- Add test covering the public run_all API

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68bd50aaccec8322a98ff5a22c260904