### PR TITLE
Include run context in manifest key_values

### DIFF
--- a/kielproc/run_easy.py
+++ b/kielproc/run_easy.py
@@ -602,6 +602,13 @@ class Orchestrator:
             "qa_gates": qa_gates,
             "inputs": inputs,
         }
+        manifest.setdefault("key_values", {}).update({
+            "qa_gates": qa_gates,
+            "site": getattr(self.run.site, "name", "DefaultSite"),
+            "baro_override_Pa": self.run.baro_override_Pa,
+            "venturi_r": venturi.get("r"),
+            "venturi_beta": venturi.get("beta"),
+        })
         skipped = getattr(self, "_skipped", [])
         if skipped:
             manifest["skipped_files"] = [

--- a/tests/test_run_easy_summary.py
+++ b/tests/test_run_easy_summary.py
@@ -40,6 +40,9 @@ def test_summary_contains_required_keys(tmp_path):
         "venturi_beta": None,
         "transmitter_span": None,
         "transmitter_setpoints": None,
+        "qa_gates": {"delta_opp_max": 0.01, "w_max": 0.002},
+        "site": "Dummy",
+        "baro_override_Pa": None,
     }
     assert manifest["key_values"] == expected_keys
     assert manifest["qa_gates"] == {"delta_opp_max": 0.01, "w_max": 0.002}


### PR DESCRIPTION
## Summary
- Extend summary.json manifest to include QA gates, site info, barometric override, and venturi parameters inside `key_values`
- Update tests for augmented manifest structure

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bd52a289dc8322b3dceabccda0dc6b