### PR TITLE
Require explicit duct geometry and audit venturi mapping

### DIFF
--- a/tests/test_run_easy_summary.py
+++ b/tests/test_run_easy_summary.py
@@ -38,6 +38,8 @@ def test_summary_contains_required_keys(tmp_path):
         "lag_samples": None,
         "venturi_r": None,
         "venturi_beta": None,
+        "venturi_area_ratio": None,
+        "venturi_mapping": "qt = r^2 * qs; dp = (1 - beta^4) * qt",
         "transmitter_span": None,
         "transmitter_setpoints": None,
         "qa_gates": {"delta_opp_max": 0.01, "w_max": 0.002},


### PR DESCRIPTION
## Summary
- require duct geometry presets to define duct_area_m2 or both duct_height_m & duct_width_m
- enforce strict warning/skip when venturi area ratio `r` is missing
- record venturi_area_ratio and venturi_mapping audit keys in summary manifest

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68be748e22a08322adb46e4138c4110f