### PR TITLE
Add operator-focused RunEasy GUI and track geometry source

### DIFF
--- a/kielproc/run_easy.py
+++ b/kielproc/run_easy.py
@@ -612,15 +612,19 @@ class Orchestrator:
             "qa_gates": qa_gates,
             "inputs": inputs,
         }
-        manifest.setdefault("key_values", {}).update({
+        kv = {
             "qa_gates": qa_gates,
-            "site": getattr(self.run.site, "name", "DefaultSite"),
+            "site": getattr(self.run.site, "name", "AdHoc"),
             "baro_override_Pa": self.run.baro_override_Pa,
             "venturi_r": venturi.get("r"),
             "venturi_beta": venturi.get("beta"),
-            "venturi_area_ratio": venturi.get("r"),           # r = As/At
+            "venturi_area_ratio": venturi.get("r"),  # r = As/At
             "venturi_mapping": "qt = r^2 * qs; dp = (1 - beta^4) * qt",
-        })
+        }
+        gsrc = getattr(self.run.site, "_geometry_source", None)
+        if gsrc:
+            kv["geometry_source"] = gsrc
+        manifest.setdefault("key_values", {}).update(kv)
         skipped = getattr(self, "_skipped", [])
         if skipped:
             manifest["skipped_files"] = [


### PR DESCRIPTION
## Summary
- Replace legacy GUI with a streamlined operator-first interface that accepts geometry via text boxes and optionally uses preset site geometry
- Log the geometry source in run results so the summary manifest notes whether presets or text input were used

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68be85be8a008322a0bae36cb86d5c8b