### PR TITLE
Add venturi mapping to run_all pipeline

### DIFF
--- a/tests/test_run_all_pipeline.py
+++ b/tests/test_run_all_pipeline.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import json
 import pandas as pd
 
 from kielproc.run_easy import RunConfig, SitePreset, run_all
@@ -27,7 +28,10 @@ def test_run_all_produces_outputs(tmp_path):
         input_dir=str(in_dir),
         output_dir=str(out_dir),
         enable_site=True,
-        site=SitePreset(name="SiteA", geometry={"duct_width_m": 1.0, "duct_height_m": 1.0}),
+        site=SitePreset(
+            name="SiteA",
+            geometry={"duct_width_m": 1.0, "duct_height_m": 1.0, "throat_area_m2": 0.25},
+        ),
         setpoints_csv=str(sp_csv),
     )
 
@@ -41,3 +45,9 @@ def test_run_all_produces_outputs(tmp_path):
     assert summary["setpoints"]["rows"] == 2
     assert summary["baro_pa"] == 101_325.0
     assert summary["site_name"] == "SiteA"
+    # Venturi result files present and sane
+    vr = Path(summary["venturi_result_json"])
+    assert vr.exists()
+    data = json.loads(vr.read_text())
+    assert len(data["curve"]) == 10
+    assert data["dp_vent_Pa_at_Qs"] > 0


### PR DESCRIPTION
## Summary
- allow resolving throat area from beta or vice versa in run_easy
- compute venturi differential pressure mapping and write result artifacts
- expose venturi mapping path in run summary and cover with tests

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68beb08003e4832292939155b783208a