### PR TITLE
chore: drop workbook lookup remnants

### DIFF
--- a/kielproc/run_easy.py
+++ b/kielproc/run_easy.py
@@ -59,7 +59,6 @@ class RunConfig:
     setpoints_slope_sign: int = +1
     # Season selector (sole user input for flow lookup)
     season: str = "summer"              # "summer" | "winter"
-    # Optional site defaults: calib_820_summer / calib_820_winter
     lookup_dp_max_mbar: float = 10.0
 
 


### PR DESCRIPTION
## Summary
- tidy `run_easy` flow lookup config so season is only selectable knob

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68bfee2efdac8322ad1985445c2e5c59