### PR TITLE
GUI: remove advanced calibration inputs

### DIFF
--- a/runeasy_gui.py
+++ b/runeasy_gui.py
@@ -251,18 +251,19 @@ class App(tk.Tk):
                     cfg.site.defaults["venturi_Cd"] = float(self.cd_entry.get().strip())
                 except Exception:
                     pass
-            # Season + optional CSV
-            cfg.season = (self.season.get().strip() or "summer")
-            if self.sp_csv.get().strip():
-                cfg.setpoints_csv = self.sp_csv.get().strip()
-                try:
-                    cfg.setpoints_min_frac = float(self.sp_min.get().strip() or "0.6")
-                except Exception:
-                    cfg.setpoints_min_frac = 0.6
-                try:
-                    cfg.setpoints_slope_sign = int(self.sp_sign.get().strip() or "+1")
-                except Exception:
-                    cfg.setpoints_slope_sign = +1
+
+        # Season + optional CSV overlay always available
+        cfg.season = (self.season.get().strip() or "summer")
+        if self.sp_csv.get().strip():
+            cfg.setpoints_csv = self.sp_csv.get().strip()
+            try:
+                cfg.setpoints_min_frac = float(self.sp_min.get().strip() or "0.6")
+            except Exception:
+                cfg.setpoints_min_frac = 0.6
+            try:
+                cfg.setpoints_slope_sign = int(self.sp_sign.get().strip() or "+1")
+            except Exception:
+                cfg.setpoints_slope_sign = +1
 
         self.run_btn.configure(state="disabled")
         self.status.configure(text="Running…")


### PR DESCRIPTION
## Summary
- simplify runeasy GUI by dropping unused advanced calibration fields
- always apply season selection and optional CSV overlay

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68bff06cc8a08322ab16b32c70fa7b8c