### PR TITLE
Use barometric pressure from workbooks

### DIFF
--- a/tests/test_run_all_pipeline.py
+++ b/tests/test_run_all_pipeline.py
@@ -113,4 +113,4 @@ def test_run_all_accepts_workbook(tmp_path):
     assert abs(dfp["DP_mbar"].iloc[1] - ((12.0 - 4.0) / 16.0 * 6.7)) < 1e-6
     # Barometric pressure extracted from workbook Data sheet
     assert summary["baro_pa"] == 101_600.0
-    assert summary["baro"]["status"] == "ok"
+    assert summary["baro_source"]["source"] == "workbook"


### PR DESCRIPTION
## Summary
- In workbook mode, read barometric pressure from Data!H15:I19 and override the provided setting
- Include `baro_source` metadata in `summary.json`
- Exercise workbook barometric pressure handling in tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68c0ed31f2c08322acf2b0c29ad1a7d3