### PR TITLE
Include barometric pressure source on report cover

### DIFF
--- a/kielproc/report_pdf.py
+++ b/kielproc/report_pdf.py
@@ -29,7 +29,11 @@ def _fig_cover(outdir: Path, summary_path: Path) -> plt.Figure:
     if s:
         lines.append(f"Site: {s.get('site_name','')}")
         bp = s.get("baro_pa", None)
-        if isinstance(bp, (int, float)): lines.append(f"Barometric pressure: {bp:.0f} Pa")
+        if isinstance(bp, (int, float)):
+            bs = s.get("baro_source", {})
+            src = bs.get("source", "")
+            extra = f" ({bs.get('cell','')}, {bs.get('unit_raw','')})" if src == "workbook" else ""
+            lines.append(f"Barometric pressure: {bp:.0f} Pa  [{src}{extra}]")
         lines.append(f"Input mode: {s.get('input_mode','')}")
         lines.append(f"Prepared input: {s.get('prepared_input_dir','')}")
         if s.get("beta") is not None or s.get("r") is not None:


### PR DESCRIPTION
## Summary
- Display barometric pressure source info on report PDF cover, including workbook cell/unit when sourced from a workbook

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c0ef357d2083228847a76f3cdbb69d