### PR TITLE
Add process temperature extraction from legacy workbook

### DIFF
--- a/tests/test_extract_temperature.py
+++ b/tests/test_extract_temperature.py
@@ -2,7 +2,10 @@ from pathlib import Path
 
 from openpyxl import Workbook
 
-from kielproc.tools.legacy_overlay import extract_temperature_from_workbook
+from kielproc.tools.legacy_overlay import (
+    extract_temperature_from_workbook,
+    extract_process_temperature_from_workbook,
+)
 
 
 def test_extract_temperature_from_workbook(tmp_path):
@@ -18,4 +21,19 @@ def test_extract_temperature_from_workbook(tmp_path):
     assert res["status"] == "ok"
     assert abs(res["T_K"] - (20.0 + 273.15)) < 1e-6
     assert res["cell"] == "Data!I15"
+
+
+def test_extract_process_temperature_from_workbook(tmp_path):
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Data"
+    ws.append(["Ambient", "C", 25.0])
+    ws.append(["Primary Air Temp", "C", 150.0])
+    f = tmp_path / "wb.xlsx"
+    wb.save(f)
+
+    res = extract_process_temperature_from_workbook(Path(f))
+    assert res["status"] == "ok"
+    assert abs(res["T_K"] - (150.0 + 273.15)) < 1e-6
+    assert res["cell"] == "Data!C2"
 


### PR DESCRIPTION
## Summary
- add `extract_process_temperature_from_workbook` to retrieve primary air/process temperatures in Kelvin
- export new function and test its heuristics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c13759ec688322baed941d9f2892b4