### PR TITLE
feat: show plane static provenance

### DIFF
--- a/kielproc/report_pdf.py
+++ b/kielproc/report_pdf.py
@@ -566,6 +566,13 @@ def _page_density_geometry(outdir: Path, summary_path: Path) -> plt.Figure:
         L.append(f"  • A1 = {A1:.4f} m^2")
     if At   is not None:
         L.append(f"  • At = {At:.4f} m^2")
+    # plane static provenance from normalization meta
+    norm_meta = Path(outdir) / "normalize_meta.json"
+    if norm_meta.exists():
+        nm = json.loads(norm_meta.read_text())
+        L.append(
+            f"  • plane static source: {nm.get('p_abs_source','n/a')}  (baro_pa_used={nm.get('baro_pa_used','n/a')})"
+        )
     return _fig_text("Density & Geometry", L)
 
 


### PR DESCRIPTION
## Summary
- report plane-static pressure source on the Density & Geometry page using `normalize_meta.json`

## Testing
- `python -m pip install -r requirements.txt -c constraints.txt`
- `python -m pip install pytest`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68c1577446548322876fe3a331042b70