### PR TITLE
report_pdf: display normalization sanity metadata

### DIFF
--- a/kielproc/report_pdf.py
+++ b/kielproc/report_pdf.py
@@ -573,6 +573,11 @@ def _page_density_geometry(outdir: Path, summary_path: Path) -> plt.Figure:
         L.append(
             f"  • plane static source: {nm.get('p_abs_source','n/a')}  (baro_pa_used={nm.get('baro_pa_used','n/a')})"
         )
+        snty = nm.get("sanity", {})
+        if snty:
+            L.append(
+                f"  • sanity: median p_s={snty.get('p_s_pa_median','n/a')} Pa; median T={snty.get('T_K_median','n/a')} K"
+            )
     return _fig_text("Density & Geometry", L)
 
 


### PR DESCRIPTION
## Summary
- include normalization sanity statistics (median p_s and T) on the Density & Geometry page of the generated PDF

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c26c654b788322a2d38e2c32e22c4c