### PR TITLE
Add transmitter profiles configuration

### DIFF
--- a/config/transmitter_profiles.json
+++ b/config/transmitter_profiles.json
@@ -1,0 +1,8 @@
+{
+  "default_range_mbar": 8.5,
+  "sites": {
+    "default": {
+      "summer": { "gain": 0.85, "bias": 5.4, "bias_unit": "tph", "full_scale_tph": 100, "range_mbar": 8.5 }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add transmitter profiles JSON with default summer profile

## Testing
- `python -m nox -s tests`


------
https://chatgpt.com/codex/tasks/task_b_68c27c93d680832298544e227b364a35