### PR TITLE
Add mA bias mode for transmitter profiles

### DIFF
--- a/tests/test_transmitter_profiles.py
+++ b/tests/test_transmitter_profiles.py
@@ -16,6 +16,31 @@ def test_derive_mc_from_gain_bias_percent():
     assert c == 10.0 * 200.0 / 100.0
 
 
+def test_derive_mc_from_gain_bias_ma_pre_scale():
+    m, c = derive_mc_from_gain_bias(
+        2.0,
+        1.5,
+        range_mbar=50.0,
+        full_scale_tph=100.0,
+        bias_unit="mA",
+    )
+    assert m == 2.0 * 100.0 / 50.0
+    assert c == (2.0 * 100.0 / 16.0) * 1.5
+
+
+def test_derive_mc_from_gain_bias_ma_flow_output():
+    m, c = derive_mc_from_gain_bias(
+        2.0,
+        1.5,
+        range_mbar=50.0,
+        full_scale_tph=100.0,
+        bias_unit="mA",
+        bias_mode="flow_output",
+    )
+    assert m == 2.0 * 100.0 / 50.0
+    assert c == (100.0 / 16.0) * 1.5
+
+
 def test_load_tx_profile_gain_bias(tmp_path: Path):
     profile = {
         "summer": {
@@ -35,3 +60,26 @@ def test_load_tx_profile_gain_bias(tmp_path: Path):
     assert c == 5.0
     assert rng == 50.0
     assert meta["source_file"] == str(f)
+
+
+def test_load_tx_profile_gain_bias_ma(tmp_path: Path):
+    profile = {
+        "winter": {
+            "gain": 2.0,
+            "bias": 1.5,
+            "range_mbar": 50.0,
+            "full_scale_tph": 100.0,
+            "bias_unit": "mA",
+            "bias_mode": "flow_output",
+        }
+    }
+    f = tmp_path / "mysite.json"
+    f.write_text(json.dumps(profile))
+    res = load_tx_profile("mysite", "winter", [tmp_path])
+    assert res is not None
+    m, c, rng, meta = res
+    assert abs(m - (2.0 * 100.0 / 50.0)) < 1e-9
+    assert c == (100.0 / 16.0) * 1.5
+    assert rng == 50.0
+    assert meta["bias_unit"] == "ma"
+    assert meta["bias_mode"] == "flow_output"


### PR DESCRIPTION
## Summary
- support deriving m,c when bias is specified in mA
- parse and return `bias_mode`/`bias_unit` in transmitter profiles
- test mA bias conversions and profile loading

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68c28cb38fb0832282323b90ffd4e1b0