### PR TITLE
Add reference flag to combined flow lookup

### DIFF
--- a/kielproc/transmitter_flow.py
+++ b/kielproc/transmitter_flow.py
@@ -150,9 +150,11 @@ def write_lookup_outputs(
     # combined vertical union with source flags
     ref_blk = ref.copy()
     ref_blk["source"] = "reference"
+    ref_blk["is_reference"] = True
     ref_blk["range_mbar"] = span
     ov_blk = overlay.copy()
     ov_blk["source"] = "overlay"
+    ov_blk["is_reference"] = False
     ov_blk["range_mbar"] = span
     combined = pd.concat([ref_blk, ov_blk], axis=0, ignore_index=True)
     combined_csv = outdir / "transmitter_lookup_combined.csv"

--- a/tests/test_run_all_pipeline.py
+++ b/tests/test_run_all_pipeline.py
@@ -50,6 +50,8 @@ def test_run_all_produces_outputs(tmp_path):
     combined = out_dir / "_integrated" / "transmitter_lookup_combined.csv"
     assert ref.exists()
     assert combined.exists()
+    df_combined = pd.read_csv(combined)
+    assert "is_reference" in df_combined.columns
     overlay = Path(summary["flow_lookup"]["overlay_csv"])
     assert overlay.exists()
     assert Path(summary["flow_lookup"]["combined_csv"]).exists()


### PR DESCRIPTION
## Summary
- flag reference vs overlay rows in combined transmitter lookup table
- test combined table includes new `is_reference` column

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68c3c0ab5f788322a7ad9025eceda486