### PR TITLE
Expose transmitter K in summary

### DIFF
--- a/kielproc/run_easy.py
+++ b/kielproc/run_easy.py
@@ -453,6 +453,9 @@ def run_all(cfg: RunConfig) -> Dict[str, Any]:
     summary["c_820"] = cal.get("c_820")
     summary["dp_range_mbar"] = cal.get("range_mbar")
     summary["operating_band_mbar"] = (tx_meta or {}).get("operating_band_mbar")
+    # Also expose K for any legacy readers
+    if cal.get("K_uic") is not None:
+        summary["K_uic"] = cal["K_uic"]
     (outdir / "summary.json").write_text(json.dumps(summary, indent=2))
 
     # ---------------------- Single PDF report ------------------------

--- a/tests/test_run_all_pipeline.py
+++ b/tests/test_run_all_pipeline.py
@@ -57,6 +57,7 @@ def test_run_all_produces_outputs(tmp_path):
     assert Path(summary["flow_lookup"]["combined_csv"]).exists()
     assert summary["baro_pa"] == 101_325.0
     assert summary["site_name"] == "SiteA"
+    assert summary["K_uic"] == 33.5
     # Venturi result files present and sane
     vr = Path(summary["venturi_result_json"])
     assert vr.exists()
@@ -117,3 +118,4 @@ def test_run_all_accepts_workbook(tmp_path):
     # Barometric pressure extracted from workbook Data sheet
     assert summary["baro_pa"] == 101_600.0
     assert summary["baro_source"]["source"] == "workbook"
+    assert summary["K_uic"] == 33.5


### PR DESCRIPTION
## Summary
- expose `K_uic` from transmitter calibration in `run_easy` summary output
- cover legacy field with tests verifying K value

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c3cf4ab848832284cf6c9487cb03b3