### PR TITLE
Use replicate parser for legacy workbook ingest

### DIFF
--- a/kielproc/parsers/ingest_legacy.py
+++ b/kielproc/parsers/ingest_legacy.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from .legacy_xlsx import _parse_port_sheet_with_replicates
+
+
+def ingest_port_sheet(xls_path: str, sheet_name: str) -> pd.DataFrame:
+    """
+    Returns a normalized long-form per-sample dataframe with:
+      time, static_gauge_pa, VP_pa, T_C, piccolo_mA, replicate
+    Works for replicate-layout legacy sheets (P1..P8, 4 blocks across).
+    """
+    df = pd.read_excel(xls_path, sheet_name=sheet_name, header=None)
+    out = _parse_port_sheet_with_replicates(df)
+    if out.empty:
+        raise ValueError(f"Could not parse replicate blocks on sheet {sheet_name}")
+    return out


### PR DESCRIPTION
## Summary
- integrate replicate-aware port sheet parser
- handle missing replicate blocks with error

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68c55c608eac83228cd9bfd220eb4477