### PR TITLE
Export per-port ξ profiles and fallback fit

### DIFF
--- a/kielproc/profile_xi.py
+++ b/kielproc/profile_xi.py
@@ -48,17 +48,25 @@ def aggregate_by_xi(per_sample: pd.DataFrame,
                     xi_col_candidates = ("xi","Xi","XI","xi_norm","xi_index"),
                     aj_col_candidates = ("Aj","A_j","area_frac","AreaFrac","A_xi"),
                     z_cols_by_port: Optional[Dict[int, str]] = None
-                   ) -> Tuple[Dict[int,float], Dict]:
-    """
-    Returns:
-      per_port_mean_qs: dict {port: Aj-weighted mean of median(q_s|xi)}
-      meta: {port: {n_xi, used_primary_leg, xi_col, aj_col}}
+                   ) -> Tuple[Dict[int,float], pd.DataFrame, Dict]:
+    """Aggregate q_s profiles by ξ and compute Aj-weighted means.
+
+    Returns
+    -------
+    per_port_mean_qs : dict
+        {port: Aj-weighted mean of median(q_s|xi)}
+    profile_df : DataFrame
+        Long-form per-port profile with columns ``[Port, xi, Aj, q_s_median, q_s_smoothed]``
+    meta : dict
+        {port: {n_xi, used_primary_leg, xi_col, aj_col}}
+
     Falls back to time-median if xi/Aj not available.
     """
     xi_col = _best_col(per_sample, xi_col_candidates)
     aj_col = _best_col(per_sample, aj_col_candidates)
-    per_port_mean = {}
-    meta = {}
+    per_port_mean: Dict[int, float] = {}
+    meta: Dict[int, Dict] = {}
+    profile_rows = []
     for p, qcol in qcols_by_port.items():
         q = pd.to_numeric(per_sample[qcol], errors="coerce")
         m_keep = np.ones(len(q), dtype=bool)
@@ -77,26 +85,41 @@ def aggregate_by_xi(per_sample: pd.DataFrame,
             "Aj": pd.to_numeric(per_sample[aj_col], errors="coerce"),
             "qs": q,
             "keep": m_keep,
-        }).dropna(subset=["xi","Aj","qs"])
+        }).dropna(subset=["xi", "Aj", "qs"])
         if df.empty:
             per_port_mean[p] = float(np.nan)
             meta[p] = {"n_xi": 0, "used_primary_leg": False, "xi_col": xi_col, "aj_col": aj_col}
             continue
         # group by xi (rounded to 3 decimals to collapse repeats), take median qs per xi
         df["xi_b"] = df["xi"].round(3)
-        g = df[df["keep"]].groupby("xi_b", as_index=False).agg(qs_med=("qs","median"),
-                                                               Aj_med=("Aj","median"))
+        g = df[df["keep"]].groupby("xi_b", as_index=False).agg(
+            qs_med=("qs", "median"), Aj_med=("Aj", "median")
+        )
         if g.empty:
             per_port_mean[p] = float(np.nan)
             meta[p] = {"n_xi": 0, "used_primary_leg": False, "xi_col": xi_col, "aj_col": aj_col}
             continue
         # Aj weight normalization across xi-bins
         w = g["Aj_med"].to_numpy(dtype=float)
-        w = np.where(np.isfinite(w) & (w>0), w, 0.0)
+        w = np.where(np.isfinite(w) & (w > 0), w, 0.0)
         w = w / (np.sum(w) + 1e-12)
         qs = g["qs_med"].to_numpy(dtype=float)
         per_port_mean[p] = float(np.nansum(w * qs))
-        meta[p] = {"n_xi": int(len(g)), "used_primary_leg": bool(m_keep.any()),
-                   "xi_col": xi_col, "aj_col": aj_col}
-    return per_port_mean, meta
+        meta[p] = {
+            "n_xi": int(len(g)),
+            "used_primary_leg": bool(m_keep.any()),
+            "xi_col": xi_col,
+            "aj_col": aj_col,
+        }
+        # save profile rows for audit
+        g = g.rename(columns={"xi_b": "xi", "Aj_med": "Aj", "qs_med": "q_s_median"})
+        g["q_s_smoothed"] = g["q_s_median"].rolling(3, center=True, min_periods=1).mean()
+        g["Port"] = p
+        profile_rows.append(g[["Port", "xi", "Aj", "q_s_median", "q_s_smoothed"]])
+    profile_df = (
+        pd.concat(profile_rows, ignore_index=True)
+        if profile_rows
+        else pd.DataFrame(columns=["Port", "xi", "Aj", "q_s_median", "q_s_smoothed"])
+    )
+    return per_port_mean, profile_df, meta
 


### PR DESCRIPTION
## Summary
- Save Aj-weighted ξ profiles per port for downstream audit and calibration
- Handle transmitter calibration when timeseries is missing by using per-port profile means

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68c62e4a37ac8322be5a85365d9c142c