### PR TITLE
Add Venturi curve ISO comparison and config options

### DIFF
--- a/tests/test_run_all_pipeline.py
+++ b/tests/test_run_all_pipeline.py
@@ -65,8 +65,9 @@ def test_run_all_produces_outputs(tmp_path):
     vr = Path(summary["venturi_result_json"])
     assert vr.exists()
     data = json.loads(vr.read_text())
-    assert len(data["flow_kg_s"]) > 10
-    assert len(data["dp_pa"]) == len(data["flow_kg_s"])
+    assert len(data["m_dot_kg_s_grid"]) > 10
+    assert len(data["dp_pa_geom_grid"]) == len(data["m_dot_kg_s_grid"])
+    assert len(data["dp_pa_iso_grid"]) == len(data["m_dot_kg_s_grid"])
     assert data["rho_kg_m3"] > 0
 
 


### PR DESCRIPTION
## Summary
- expose configurable Venturi ISO parameters in `RunConfig`
- generate geometry-only and ISO-style Venturi curves and write to `venturi_result.json`
- adapt pipeline tests for new Venturi curve structure

## Testing
- `python -m py_compile kielproc/run_easy.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c6509f646483229f36adef0a755dd0