### PR TITLE
Add predicted q_s band to run summary

### DIFF
--- a/tests/test_run_all_pipeline.py
+++ b/tests/test_run_all_pipeline.py
@@ -52,6 +52,9 @@ def test_run_all_produces_outputs(tmp_path):
     assert combined.exists()
     df_combined = pd.read_csv(combined)
     assert "is_reference" in df_combined.columns
+    # Predicted band from qs carried through summary
+    band = summary["reconcile"]["pred_band_geom_mbar"]
+    assert isinstance(band, list) and len(band) == 2
     overlay = Path(summary["flow_lookup"]["overlay_csv"])
     assert overlay.exists()
     assert Path(summary["flow_lookup"]["combined_csv"]).exists()


### PR DESCRIPTION
## Summary
- derive 5th–95th percentile DP band from q_s series and include it in reconciliation
- expose corrected DP band when a fitted C_f is available
- test that the predicted band is present in run summaries

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c6792fcaa08322a47ceedaf3906733