### PR TITLE
Ensure overlay plots use raw differential pressure

### DIFF
--- a/kielproc/run_easy.py
+++ b/kielproc/run_easy.py
@@ -618,6 +618,8 @@ def run_all(cfg: RunConfig) -> Dict[str, Any]:
     overlay_df = pd.DataFrame()
     if I_series is not None:
         overlay_df["data_DP_mbar_raw"] = current_to_dp_raw_mbar(I_series, lrv_mbar, urv_mbar)
+        # Canonical overlay column expected by downstream reports/plots
+        overlay_df["data_DP_mbar"] = overlay_df["data_DP_mbar_raw"]
     if dp_pred_mbar_series is not None:
         overlay_df["dp_pred_mbar_from_qs"] = np.asarray(dp_pred_mbar_series)
     if I_series is not None:


### PR DESCRIPTION
## Summary
- Write `data_DP_mbar` column alongside raw overlay measurements
- Use raw DP as canonical source for downstream reports and plots

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68c7cd522f608322b5667711e8a76c26